### PR TITLE
Split appveyor env into appveyor-vs and appveyor-msys

### DIFF
--- a/chapter-01/recipe-01/fortran-example/menu.yml
+++ b/chapter-01/recipe-01/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-02/fortran-example/menu.yml
+++ b/chapter-01/recipe-02/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-03/fortran-example/menu.yml
+++ b/chapter-01/recipe-03/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-05/cxx-example/menu.yml
+++ b/chapter-01/recipe-05/cxx-example/menu.yml
@@ -1,4 +1,8 @@
-appveyor:
+appveyor-vs:
+  definitions:
+    - USE_LIBRARY: 'ON'
+
+appveyor-msys:
   definitions:
     - USE_LIBRARY: 'ON'
 

--- a/chapter-01/recipe-06/fortran-example/menu.yml
+++ b/chapter-01/recipe-06/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-01/recipe-07/cxx-example/menu.yml
+++ b/chapter-01/recipe-07/cxx-example/menu.yml
@@ -1,7 +1,11 @@
-appveyor:
+appveyor-vs:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
     - CMAKE_CONFIGURATION_TYPES: 'Release'
+
+appveyor-msys:
+  definitions:
+    - CMAKE_BUILD_TYPE: 'Release'
 
 drone:
   definitions:

--- a/chapter-01/recipe-07/fortran-example/menu.yml
+++ b/chapter-01/recipe-07/fortran-example/menu.yml
@@ -1,10 +1,15 @@
-appveyor:
+appveyor-vs:
+  definitions:
+    - CMAKE_BUILD_TYPE: 'RelWithDebInfo'
+  failing_generators:
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
   definitions:
     - CMAKE_BUILD_TYPE: 'RelWithDebInfo'
   failing_generators:
     - 'Ninja'
-    - 'Visual Studio 14 2015 Win64'
-    - 'Visual Studio 15 2017 Win64'
 
 drone:
   definitions:

--- a/chapter-01/recipe-08/cxx-example/menu.yml
+++ b/chapter-01/recipe-08/cxx-example/menu.yml
@@ -1,4 +1,8 @@
-appveyor:
+appveyor-vs:
+  definitions:
+    - CMAKE_CXX_FLAGS: '"/EHsc- /GR-"'
+
+appveyor-msys:
   definitions:
     - CMAKE_CXX_FLAGS: '"-fno-exceptions -fno-rtti"'
 

--- a/chapter-01/recipe-09/fortran-example/menu.yml
+++ b/chapter-01/recipe-09/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 drone:
   definitions:

--- a/chapter-01/recipe-10/cxx-example/menu.yml
+++ b/chapter-01/recipe-10/cxx-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
     - CMAKE_CONFIGURATION_TYPES: 'Release'

--- a/chapter-02/recipe-03/fortran-example/menu.yml
+++ b/chapter-02/recipe-03/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-02/c-example/menu.yml
+++ b/chapter-03/recipe-02/c-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
     - CMAKE_CONFIGURATION_TYPES: 'Release'

--- a/chapter-03/recipe-03/cxx-example/menu.yml
+++ b/chapter-03/recipe-03/cxx-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
     - CMAKE_CONFIGURATION_TYPES: 'Release'

--- a/chapter-03/recipe-04/cxx-example/menu.yml
+++ b/chapter-03/recipe-04/cxx-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-05/fortran-example-3.5/menu.yml
+++ b/chapter-03/recipe-05/fortran-example-3.5/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-05/fortran-example/menu.yml
+++ b/chapter-03/recipe-05/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-03/recipe-06/c-example-3.5/menu.yml
+++ b/chapter-03/recipe-06/c-example-3.5/menu.yml
@@ -1,9 +1,11 @@
-appveyor:
+appveyor-vs:
   env:
     - MSMPI_BIN: 'C:\Program Files\Microsoft MPI\Bin\'
     - MSMPI_INC: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Include\'
     - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
     - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
+      
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-06/c-example/menu.yml
+++ b/chapter-03/recipe-06/c-example/menu.yml
@@ -1,9 +1,11 @@
-appveyor:
+appveyor-vs:
   env:
     - MSMPI_BIN: 'C:\Program Files\Microsoft MPI\Bin\'
     - MSMPI_INC: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Include\'
     - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
     - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
+
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-06/cxx-example/menu.yml
+++ b/chapter-03/recipe-06/cxx-example/menu.yml
@@ -1,9 +1,11 @@
-appveyor:
+appveyor-vs:
   env:
     - MSMPI_BIN: 'C:\Program Files\Microsoft MPI\Bin\'
     - MSMPI_INC: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Include\'
     - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
     - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
+
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-08/cxx-example/menu.yml
+++ b/chapter-03/recipe-08/cxx-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   env:
     - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
 

--- a/chapter-03/recipe-09/c-example-3.5/menu.yml
+++ b/chapter-03/recipe-09/c-example-3.5/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   failing_generators:
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/c-example/menu.yml
+++ b/chapter-03/recipe-09/c-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   failing_generators:
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/cxx-uuid-example-3.5/menu.yml
+++ b/chapter-03/recipe-09/cxx-uuid-example-3.5/menu.yml
@@ -1,6 +1,9 @@
-appveyor:
+appveyor-vs:
+  failing_generators:
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'
-    - 'Visual Studio 14 2015 Win64'
-    - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/cxx-uuid-example/menu.yml
+++ b/chapter-03/recipe-09/cxx-uuid-example/menu.yml
@@ -1,6 +1,9 @@
-appveyor:
+appveyor-vs:
+  failing_generators:
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'
-    - 'Visual Studio 14 2015 Win64'
-    - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-10/c-example/menu.yml
+++ b/chapter-03/recipe-10/c-example/menu.yml
@@ -1,3 +1,3 @@
-appveyor:
+appveyor-vs:
   definitions:
     - ZeroMQ_ROOT: 'c:\tools\vcpkg\installed\x64-windows'

--- a/chapter-04/recipe-01/cxx-example/menu.yml
+++ b/chapter-04/recipe-01/cxx-example/menu.yml
@@ -1,6 +1,10 @@
-appveyor:
+appveyor-vs:
   env:
     - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
+
+travis-osx:
+  definitions:
+    - BOOST_ROOT: '/usr/local/opt/boost@1.59'
 
 targets:
   - test

--- a/chapter-04/recipe-04/cxx-example/menu.yml
+++ b/chapter-04/recipe-04/cxx-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   env:
     - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
 

--- a/chapter-05/recipe-03/cxx-example/menu.yml
+++ b/chapter-05/recipe-03/cxx-example/menu.yml
@@ -1,7 +1,10 @@
-appveyor:
+appveyor-vs:
   failing_generators:
     - 'Visual Studio 14 2015 Win64' 
     - 'Visual Studio 15 2017 Win64' 
+
+appveyor-msys:
+  failing_generators:
     - 'Ninja'
 
 travis-linux:

--- a/chapter-05/recipe-04/cxx-example/menu.yml
+++ b/chapter-05/recipe-04/cxx-example/menu.yml
@@ -1,7 +1,10 @@
-appveyor:
+appveyor-vs:
   failing_generators:
     - 'Visual Studio 14 2015 Win64' 
     - 'Visual Studio 15 2017 Win64' 
+
+appveyor-msys:
+  failing_generators:
     - 'Ninja'
 
 travis-linux:

--- a/chapter-05/recipe-08/c-example-3.5/menu.yml
+++ b/chapter-05/recipe-08/c-example-3.5/menu.yml
@@ -1,6 +1,9 @@
-appveyor:
+appveyor-vs:
+  failing_generators:
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'
-    - 'Visual Studio 14 2015 Win64'
-    - 'Visual Studio 15 2017 Win64'

--- a/chapter-05/recipe-08/c-example/menu.yml
+++ b/chapter-05/recipe-08/c-example/menu.yml
@@ -1,6 +1,9 @@
-appveyor:
+appveyor-vs:
+  failing_generators:
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'
-    - 'Visual Studio 14 2015 Win64'
-    - 'Visual Studio 15 2017 Win64'

--- a/chapter-05/recipe-09/cxx-example/menu.yml
+++ b/chapter-05/recipe-09/cxx-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
     - CMAKE_CONFIGURATION_TYPES: 'Release'

--- a/chapter-06/recipe-01/fortran-example/menu.yml
+++ b/chapter-06/recipe-01/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-06/recipe-02/fortran-example/menu.yml
+++ b/chapter-06/recipe-02/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-06/recipe-04/fortran-example/menu.yml
+++ b/chapter-06/recipe-04/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-07/recipe-09/fortran-example/menu.yml
+++ b/chapter-07/recipe-09/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 targets:
   - test

--- a/chapter-08/recipe-05/fortran-example/menu.yml
+++ b/chapter-08/recipe-05/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 drone:
   failing_generators:

--- a/chapter-09/recipe-01/fortran-example-3.5/menu.yml
+++ b/chapter-09/recipe-01/fortran-example-3.5/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-09/recipe-01/fortran-example/menu.yml
+++ b/chapter-09/recipe-01/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-09/recipe-04/cxx-example/menu.yml
+++ b/chapter-09/recipe-04/cxx-example/menu.yml
@@ -1,4 +1,4 @@
-appveyor:
+appveyor-vs:
   env:
     - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
 

--- a/chapter-09/recipe-06/fortran-example/menu.yml
+++ b/chapter-09/recipe-06/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 targets:
   - test

--- a/chapter-11/recipe-03/fortran-example/menu.yml
+++ b/chapter-11/recipe-03/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 travis-linux:
   failing_generators:

--- a/chapter-13/recipe-02/fortran-example/menu.yml
+++ b/chapter-13/recipe-02/fortran-example/menu.yml
@@ -2,12 +2,15 @@
 targets:
   - install
 
-appveyor:
+appveyor-vs:
+  failing_generators:
+    - 'Visual Studio 14 2015 Win64'
+    - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'
     - 'Ninja'
-    - 'Visual Studio 14 2015 Win64'
-    - 'Visual Studio 15 2017 Win64'
 
 travis-osx:
   failing_generators:

--- a/chapter-14/recipe-03/fortran-example/menu.yml
+++ b/chapter-14/recipe-03/fortran-example/menu.yml
@@ -1,8 +1,11 @@
-appveyor:
+appveyor-vs:
   failing_generators:
-    - 'Ninja'
     - 'Visual Studio 14 2015 Win64'
     - 'Visual Studio 15 2017 Win64'
+
+appveyor-msys:
+  failing_generators:
+    - 'Ninja'
 
 targets:
   - test

--- a/testing/README.md
+++ b/testing/README.md
@@ -30,8 +30,12 @@ travis-linux:
 travis-osx:
   ...
 
-# AppVeyor
-appveyor:
+# AppVeyor Visual Studio generators
+appveyor-vs:
+  ...
+
+# AppVeyor MSYS Makefiles and Ninja generators
+appveyor-msys:
   ...
 
 # Drone CI

--- a/testing/env.py
+++ b/testing/env.py
@@ -9,7 +9,11 @@ def get_ci_environment():
         else:
             ci_environment = 'travis-linux'
     elif os.environ.get('APPVEYOR'):
-        ci_environment = 'appveyor'
+        generator = os.environ.get('GENERATOR')
+        if 'Visual Studio' in generator:
+            ci_environment = 'appveyor-vs'
+        else:
+            ci_environment = 'appveyor-msys'
     elif os.environ.get('DRONE'):
         ci_environment = 'drone'
     else:

--- a/testing/menu.yml
+++ b/testing/menu.yml
@@ -1,10 +1,15 @@
-appveyor:
+appveyor-vs:
+  definitions:
+    - CMAKE_BUILD_TYPE: 'Debug'
+    - CMAKE_CONFIGURATION_TYPES: 'Debug'
+    - CMAKE_TOOLCHAIN_FILE: 'C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake'
+
+appveyor-msys:
   definitions:
     - CMAKE_C_COMPILER: 'gcc'
     - CMAKE_CXX_COMPILER: 'g++'
     - CMAKE_Fortran_COMPILER: 'gfortran'
     - CMAKE_BUILD_TYPE: 'Debug'
-    - CMAKE_CONFIGURATION_TYPES: 'Debug'
 
 drone:
   definitions:


### PR DESCRIPTION
This should give us more fine-grained control over what we install and how we use it.