### PR TITLE
Avoid code duplication marking files as generated

### DIFF
--- a/chapter-05/recipe-04/cxx-example/CMakeLists.txt
+++ b/chapter-05/recipe-04/cxx-example/CMakeLists.txt
@@ -12,14 +12,8 @@ find_package(LAPACK REQUIRED)
 add_subdirectory(deps)
 
 add_executable(linear-algebra linear-algebra.cpp)
+
 target_link_libraries(linear-algebra
   PRIVATE
     math
   )
-set_source_files_properties(
-  ${CMAKE_CURRENT_BINARY_DIR}/deps/wrap_BLAS_LAPACK/CxxBLAS.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/deps/wrap_BLAS_LAPACK/CxxLAPACK.hpp
-  PROPERTIES
-    GENERATED TRUE
-  )
-add_dependencies(linear-algebra BLAS_LAPACK_wrappers)

--- a/chapter-05/recipe-04/cxx-example/CMakeLists.txt
+++ b/chapter-05/recipe-04/cxx-example/CMakeLists.txt
@@ -1,13 +1,10 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-project(recipe-04 LANGUAGES CXX C Fortran)
+project(recipe-04 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-find_package(BLAS REQUIRED)
-find_package(LAPACK REQUIRED)
 
 add_subdirectory(deps)
 

--- a/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
+++ b/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
@@ -20,22 +20,25 @@ set_source_files_properties(
   )
 
 add_library(math "")
+
 target_sources(math
   PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.cpp
-  PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.hpp
   )
+
 target_include_directories(math
   PUBLIC
-    ${CMAKE_CURRENT_BINARY_DIR}/deps
+    ${CMAKE_CURRENT_BINARY_DIR}
   INTERFACE
     ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK
   )
+
 target_link_libraries(math
   PUBLIC
     ${LAPACK_LIBRARIES}
   )
+
 add_dependencies(math BLAS_LAPACK_wrappers)

--- a/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
+++ b/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
@@ -1,4 +1,25 @@
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
+
+set(MATH_SRCS
+    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.hpp
+    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.hpp)
+
 add_custom_target(BLAS_LAPACK_wrappers
+  WORKING_DIRECTORY
+    ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS
+    ${MATH_SRCS}
+  COMMENT
+    "Intermediate BLAS_LAPACK_wrappers target"
+  VERBATIM
+  )
+
+add_custom_command(
+  OUTPUT
+    ${MATH_SRCS}
   COMMAND
     ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_SOURCE_DIR}/wrap_BLAS_LAPACK.tar.gz
   WORKING_DIRECTORY
@@ -7,26 +28,13 @@ add_custom_target(BLAS_LAPACK_wrappers
     ${CMAKE_CURRENT_SOURCE_DIR}/wrap_BLAS_LAPACK.tar.gz
   COMMENT
     "Unpacking C++ wrappers for BLAS/LAPACK"
-  VERBATIM
-  )
-
-set_source_files_properties(
-  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.hpp
-  PROPERTIES
-    GENERATED TRUE
-  )
+)
 
 add_library(math "")
 
 target_sources(math
   PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.hpp
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.hpp
+    ${MATH_SRCS}
   )
 
 target_include_directories(math
@@ -38,7 +46,7 @@ target_include_directories(math
 
 target_link_libraries(math
   PUBLIC
-    ${LAPACK_LIBRARIES}
+    ${LAPACK_LIBRARIES} # not need of ${BLAS_LIBRARIES} it is included in ${LAPACK_LIBRARIES}
   )
 
 add_dependencies(math BLAS_LAPACK_wrappers)

--- a/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
+++ b/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
@@ -2,10 +2,11 @@ find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
 set(MATH_SRCS
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.hpp
-    ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.hpp)
+  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxBLAS.hpp
+  ${CMAKE_CURRENT_BINARY_DIR}/wrap_BLAS_LAPACK/CxxLAPACK.hpp
+  )
 
 add_custom_target(BLAS_LAPACK_wrappers
   WORKING_DIRECTORY
@@ -46,7 +47,7 @@ target_include_directories(math
 
 target_link_libraries(math
   PUBLIC
-    ${LAPACK_LIBRARIES} # not need of ${BLAS_LIBRARIES} it is included in ${LAPACK_LIBRARIES}
+    ${LAPACK_LIBRARIES}  # ${BLAS_LIBRARIES} are included in ${LAPACK_LIBRARIES}
   )
 
 add_dependencies(math BLAS_LAPACK_wrappers)

--- a/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
+++ b/chapter-05/recipe-04/cxx-example/deps/CMakeLists.txt
@@ -49,5 +49,3 @@ target_link_libraries(math
   PUBLIC
     ${LAPACK_LIBRARIES}  # ${BLAS_LIBRARIES} are included in ${LAPACK_LIBRARIES}
   )
-
-add_dependencies(math BLAS_LAPACK_wrappers)


### PR DESCRIPTION
@TheErk this change solves the problem with code duplication marking files as generated but I do not understand why it works :-) since all sources are now `PRIVATE`. Does this change make any sense? I agree with you that previously this was clunky.