### PR TITLE
Rework invocation of bash in batch scripts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,6 +62,8 @@ init:
   # Remove Python 2.7 from path
   - set PATH=%PATH:C:\Python27;=%
   - set PATH=%PATH:C:\Python27\Scripts;=%
+  # Add Anaconda to PATH
+  - set PATH=C:\Deps\conda\Scripts;C:\Deps\conda\library\bin;%PATH%
 
 cache:
   - c:\msys64\var\cache\pacman\pkg -> testing\dependencies\appveyor\install.bat

--- a/chapter-11/recipe-04/cxx-example/custom.sh
+++ b/chapter-11/recipe-04/cxx-example/custom.sh
@@ -17,13 +17,13 @@ cp ../CMakeLists.txt .
 cp ../example.cpp .
 
 if [[ "$OSTYPE" == "msys" ]]; then
-    /c/deps/conda/scripts/conda.exe config --set always_yes yes --set changeps1 no
+    conda.exe config --set always_yes yes --set changeps1 no
 
-    /c/deps/conda/scripts/conda.exe build conda-recipe
+    conda.exe build conda-recipe
 
-    /c/deps/conda/scripts/conda.exe install --use-local conda-example-simple
+    conda.exe install --use-local conda-example-simple
 
-    /c/deps/conda/library/bin/hello-conda.exe
+    hello-conda.exe
 else
     PATH=$HOME/Deps/conda/bin${PATH:+:$PATH}
 

--- a/chapter-11/recipe-05/cxx-example/custom.sh
+++ b/chapter-11/recipe-05/cxx-example/custom.sh
@@ -17,13 +17,13 @@ cp ../CMakeLists.txt .
 cp ../example.cpp .
 
 if [[ "$OSTYPE" == "msys" ]]; then
-    /c/deps/conda/scripts/conda.exe config --set always_yes yes --set changeps1 no
+    conda.exe config --set always_yes yes --set changeps1 no
 
-    /c/deps/conda/scripts/conda.exe build conda-recipe
+    conda.exe build conda-recipe
 
-    /c/deps/conda/scripts/conda.exe install --use-local conda-example-dgemm
+    conda.exe install --use-local conda-example-dgemm
 
-    /c/deps/conda/library/bin/dgemm-example.exe
+    dgemm-example.exe
 else
     PATH=$HOME/Deps/conda/bin${PATH:+:$PATH}
 

--- a/testing/dependencies/appveyor/extract.bat
+++ b/testing/dependencies/appveyor/extract.bat
@@ -2,7 +2,7 @@ rem we download and extract and use the zip instead of the git clone
 rem to avoid issues with symlinks
 
 rem the 7z that is default on appveyor cannot handle symlinks but p7zip can
-bash -lc "pacman -S --noconfirm p7zip"
+bash "pacman -S --noconfirm p7zip"
 
-bash -lc "cd /c/projects/ && 7z x ${APPVEYOR_REPO_COMMIT}.zip"
-bash -lc "mv /c/projects/cmake-cookbook-${APPVEYOR_REPO_COMMIT} /c/projects/cmake-cookbook-no-symlinks"
+bash "cd /c/projects/ && 7z x ${APPVEYOR_REPO_COMMIT}.zip"
+bash "mv /c/projects/cmake-cookbook-${APPVEYOR_REPO_COMMIT} /c/projects/cmake-cookbook-no-symlinks"

--- a/testing/dependencies/appveyor/extract.bat
+++ b/testing/dependencies/appveyor/extract.bat
@@ -2,7 +2,7 @@ rem we download and extract and use the zip instead of the git clone
 rem to avoid issues with symlinks
 
 rem the 7z that is default on appveyor cannot handle symlinks but p7zip can
-bash "pacman -S --noconfirm p7zip"
+bash -c "pacman -S --noconfirm p7zip"
 
-bash "cd /c/projects/ && 7z x ${APPVEYOR_REPO_COMMIT}.zip"
-bash "mv /c/projects/cmake-cookbook-${APPVEYOR_REPO_COMMIT} /c/projects/cmake-cookbook-no-symlinks"
+bash -c "cd /c/projects/ && 7z x ${APPVEYOR_REPO_COMMIT}.zip"
+bash -c "mv /c/projects/cmake-cookbook-${APPVEYOR_REPO_COMMIT} /c/projects/cmake-cookbook-no-symlinks"

--- a/testing/dependencies/appveyor/install.bat
+++ b/testing/dependencies/appveyor/install.bat
@@ -9,21 +9,21 @@ if "%nonVSGenerator%"=="true" (
   echo "Let's get MSYS64 working"
 
   rem upgrade the msys2 platform
-  bash "pacman -S --needed --noconfirm pacman-mirrors"
+  bash -c "pacman -S --needed --noconfirm pacman-mirrors"
 
   rem --ask=127 is taken from https://github.com/appveyor/ci/issues/2074#issuecomment-364842018
-  bash "pacman -Syuu --needed --noconfirm --ask=127"
+  bash -c "pacman -Syuu --needed --noconfirm --ask=127"
 
   rem search for packages with
   rem bash "pacman -Ss boost"
 
   rem more packages
-  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-boost"
-  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-ninja"
-  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-openblas"
-  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-eigen3"
-  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-pkg-config"
-  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-zeromq"
+  bash -c "pacman -S --noconfirm mingw64/mingw-w64-x86_64-boost"
+  bash -c "pacman -S --noconfirm mingw64/mingw-w64-x86_64-ninja"
+  bash -c "pacman -S --noconfirm mingw64/mingw-w64-x86_64-openblas"
+  bash -c "pacman -S --noconfirm mingw64/mingw-w64-x86_64-eigen3"
+  bash -c "pacman -S --noconfirm mingw64/mingw-w64-x86_64-pkg-config"
+  bash -c "pacman -S --noconfirm mingw64/mingw-w64-x86_64-zeromq"
 ) else (
   echo "Using VS generator %GENERATOR%"
   echo "Let's get VcPkg working"

--- a/testing/dependencies/appveyor/install.bat
+++ b/testing/dependencies/appveyor/install.bat
@@ -9,21 +9,21 @@ if "%nonVSGenerator%"=="true" (
   echo "Let's get MSYS64 working"
 
   rem upgrade the msys2 platform
-  bash -lc "pacman -S --needed --noconfirm pacman-mirrors"
+  bash "pacman -S --needed --noconfirm pacman-mirrors"
 
   rem --ask=127 is taken from https://github.com/appveyor/ci/issues/2074#issuecomment-364842018
-  bash -lc "pacman -Syuu --needed --noconfirm --ask=127"
+  bash "pacman -Syuu --needed --noconfirm --ask=127"
 
   rem search for packages with
-  rem bash -lc "pacman -Ss boost"
+  rem bash "pacman -Ss boost"
 
   rem more packages
-  bash -lc "pacman -S --noconfirm mingw64/mingw-w64-x86_64-boost"
-  bash -lc "pacman -S --noconfirm mingw64/mingw-w64-x86_64-ninja"
-  bash -lc "pacman -S --noconfirm mingw64/mingw-w64-x86_64-openblas"
-  bash -lc "pacman -S --noconfirm mingw64/mingw-w64-x86_64-eigen3"
-  bash -lc "pacman -S --noconfirm mingw64/mingw-w64-x86_64-pkg-config"
-  bash -lc "pacman -S --noconfirm mingw64/mingw-w64-x86_64-zeromq"
+  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-boost"
+  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-ninja"
+  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-openblas"
+  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-eigen3"
+  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-pkg-config"
+  bash "pacman -S --noconfirm mingw64/mingw-w64-x86_64-zeromq"
 ) else (
   echo "Using VS generator %GENERATOR%"
   echo "Let's get VcPkg working"

--- a/testing/dependencies/appveyor/test.bat
+++ b/testing/dependencies/appveyor/test.bat
@@ -1,20 +1,20 @@
 rem install pipenv dependencies
-bash "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
+bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
 
 rem finally we start with the actual tests
 if "%ANACONDA_TESTS_ONLY%"=="1" (
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
 ) else (
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-03'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-02'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'"
-  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-03'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-02'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'"
+  bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'"
 )

--- a/testing/dependencies/appveyor/test.bat
+++ b/testing/dependencies/appveyor/test.bat
@@ -1,20 +1,20 @@
 rem install pipenv dependencies
-bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
+bash "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
 
 rem finally we start with the actual tests
 if "%ANACONDA_TESTS_ONLY%"=="1" (
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
 ) else (
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-03'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-02'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'"
-  bash -lc "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-03'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-02'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'"
+  bash "cd /c/projects/cmake-cookbook-no-symlinks && pwd && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'"
 )


### PR DESCRIPTION
`bash` can be called with just `-c` rather than `-lc`. This allows `PATH` exported in `.appveyor.yml` to be preserved and simplify a bit the `custom.sh`. This addresses #389 
@bast this is ready to go and I suggest you squash-merge it.