### PR TITLE
Install Miniconda and build tools rather than full Anaconda

### DIFF
--- a/testing/dependencies/appveyor/anaconda.ps1
+++ b/testing/dependencies/appveyor/anaconda.ps1
@@ -5,6 +5,7 @@
 
 function DownloadAnaconda () {
     $webclient = New-Object System.Net.WebClient
+    $filename = "Miniconda3-latest-Windows-x86_64.exe"
     $url = "https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe"
 
     $basedir = $pwd.Path + "\"

--- a/testing/dependencies/appveyor/anaconda.ps1
+++ b/testing/dependencies/appveyor/anaconda.ps1
@@ -3,10 +3,9 @@
 # License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
 # Modified by Roberto Di Remigio to install Anaconda
 
-function DownloadAnaconda ($Anaconda_VERSION) {
+function DownloadAnaconda () {
     $webclient = New-Object System.Net.WebClient
-    $filename = "Anaconda3-" + $Anaconda_VERSION + "-Windows-x86_64.exe"
-    $url = "https://repo.anaconda.com/archive/" + $filename
+    $url = "https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe"
 
     $basedir = $pwd.Path + "\"
     $filepath = $basedir + $filename
@@ -36,22 +35,22 @@ function DownloadAnaconda ($Anaconda_VERSION) {
    return $filepath
 }
 
-function InstallAnaconda ($Anaconda_VERSION, $Anaconda_cache) {
-    Write-Host "Installing Anaconda" $Anaconda_VERSION
+function InstallAnaconda ($Anaconda_cache) {
+    Write-Host "Installing latest Miniconda"
     if (Test-Path $Anaconda_cache) {
-        Write-Host "-- Anaconda " $Anaconda_VERSION "FOUND in cache"
+        Write-Host "-- Miniconda latest version FOUND in cache"
         return $false
     }
 
-    Write-Host "-- Anaconda" $Anaconda_VERSION "NOT FOUND in cache"
-    $filepath = DownloadAnaconda $Anaconda_VERSION
+    Write-Host "-- Miniconda latest version NOT FOUND in cache"
+    $filepath = DownloadAnaconda
     Write-Host "Installing" $filepath "to" $Anaconda_cache
     $install_log = $Anaconda_cache + ".log"
     $args = "/InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /S /D=$Anaconda_cache"
     Write-Host $filepath $args
     Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
     if (Test-Path $Anaconda_cache) {
-        Write-Host "Anaconda $Anaconda_VERSION installation complete"
+        Write-Host "Miniconda latest version installation complete"
     } else {
         Write-Host "Failed to install Python in $Anaconda_cache"
         Get-Content -Path $install_log
@@ -63,11 +62,31 @@ function SetUpConda ($Anaconda_cache) {
     $conda_path = $Anaconda_cache + "\Scripts\conda.exe"
     Write-Host "Setting up conda..."
 
-    $args = "config --set always_yes yes --set changeps1 no"
+    $args = "config --set show_channel_urls True"
     Write-Host $conda_path $args
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 
-    $args = "update -q conda"
+    $args = "config --set always_yes yes"
+    Write-Host $conda_path $args
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+
+    $args = "config --set changeps1 no"
+    Write-Host $conda_path $args
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+
+    $args = "update --all --yes"
+    Write-Host $conda_path $args
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+
+    $args = "clean -tipy"
+    Write-Host $conda_path $args
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+
+    $args = "install --yes --quiet conda-build anaconda-client jinja2 setuptools"
+    Write-Host $conda_path $args
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+
+    $args = "clean -tipsy"
     Write-Host $conda_path $args
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 
@@ -78,11 +97,10 @@ function SetUpConda ($Anaconda_cache) {
 
 
 function main () {
-    $Anaconda_VERSION = "5.2.0"
     $Anaconda_cache = "C:\Deps\conda"
     If ($env:ANACONDA_TESTS_ONLY -eq 1) {
-        Write-Host "-- ANACONDA_TESTS_ONLY is set, hence installing version" $Anaconda_VERSION
-        InstallAnaconda $Anaconda_VERSION $Anaconda_cache
+        Write-Host "-- ANACONDA_TESTS_ONLY is set, hence installing latest Miniconda"
+        InstallAnaconda $Anaconda_cache
         SetUpConda $Anaconda_cache
     } Else {
         Write-Host "-- ANACONDA_TESTS_ONLY is not set, hence not installing it!"

--- a/testing/dependencies/travis/anaconda.sh
+++ b/testing/dependencies/travis/anaconda.sh
@@ -2,27 +2,32 @@
 
 set -eu -o pipefail
 
-Anaconda_VERSION="5.2.0"
-echo "-- Installing Anaconda $Anaconda_VERSION"
+echo "-- Installing latest Miniconda"
 if [[ -d "$HOME/Deps/conda/bin" ]]; then
-  echo "-- Anaconda $Anaconda_VERSION FOUND in cache"
+    echo "-- Miniconda latest version FOUND in cache"
 else
-  cd "$HOME"/Downloads
-  echo "-- Anaconda $Anaconda_VERSION NOT FOUND in cache"
-  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    curl -Ls https://repo.continuum.io/archive/Anaconda3-${Anaconda_VERSION}-Linux-x86_64.sh > conda.sh
-  elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    curl -Ls https://repo.continuum.io/archive/Anaconda3-${Anaconda_VERSION}-MacOSX-x86_64.sh > conda.sh
-  fi
-  # Travis creates the cached directories for us.
-  # This is problematic when wanting to install Anaconda for the first time...
-  rm -rf "$HOME"/Deps/conda
-  bash conda.sh -b -p "$HOME"/Deps/conda
-  PATH=$HOME/Deps/conda/bin${PATH:+:$PATH}
-  conda config --set always_yes yes --set changeps1 no
-  conda update -q conda
-  conda info -a
-  cd "$TRAVIS_BUILD_DIR"
-  rm -f "$HOME"/Downloads/conda.sh
+    cd "$HOME"/Downloads
+    echo "-- Miniconda latest version NOT FOUND in cache"
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        curl -Ls https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        curl -Ls https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > miniconda.sh
+    fi
+    # Travis creates the cached directories for us.
+    # This is problematic when wanting to install Anaconda for the first time...
+    rm -rf "$HOME"/Deps/conda
+    bash miniconda.sh -b -p "$HOME"/Deps/conda &> /dev/null
+    touch "$HOME"/Deps/conda/conda-meta/pinned
+    PATH=$HOME/Deps/conda/bin${PATH:+:$PATH}
+    conda config --set show_channel_urls True &> /dev/null
+    conda config --set always_yes yes &> /dev/null
+    conda config --set changeps1 no &> /dev/null
+    conda update --all --yes &> /dev/null
+    conda clean -tipy &> /dev/null
+    # Install conda build and deployment tools.
+    conda install --yes --quiet conda-build anaconda-client jinja2 setuptools &> /dev/null
+    conda clean -tipsy &> /dev/null
+    cd "$TRAVIS_BUILD_DIR"
+    rm -f "$HOME"/Downloads/miniconda.sh
 fi
-echo "-- Done with Anaconda $Anaconda_VERSION"
+echo "-- Done with latest Miniconda"

--- a/testing/dependencies/travis/anaconda.sh
+++ b/testing/dependencies/travis/anaconda.sh
@@ -27,6 +27,7 @@ else
     # Install conda build and deployment tools.
     conda install --yes --quiet conda-build anaconda-client jinja2 setuptools &> /dev/null
     conda clean -tipsy &> /dev/null
+    conda info -a
     cd "$TRAVIS_BUILD_DIR"
     rm -f "$HOME"/Downloads/miniconda.sh
 fi


### PR DESCRIPTION
## Description
This downloads and installs Miniconda (latest Python 3 version) rather than full-fledged Anaconda. The build tools are installed as extra packages. Hopefully should reduce build times when caches are invalidated and size of cache. This was inspired by the Docker images used in the conda-forge project: 
https://github.com/conda-forge/docker-images/blob/master/scripts/run_commands#L18-L43

## Todos
  - [x] Install Miniconda rather than Anaconda on Travis
  - [x] Install Miniconda rather than Anaconda on Appveyor

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go