### PR TITLE
Prunes and reorders Appveyor test matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,28 +15,23 @@ environment:
   SHELL: "windows"
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      MSYSTEM: MINGW64
       GENERATOR: "MSYS Makefiles"
       BUILDFLAGS: "VERBOSE=1"
       CMAKEARGS: ""
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      MSYSTEM: MINGW64
       GENERATOR: "Visual Studio 15 2017 Win64"
       BUILDFLAGS: "/verbosity:normal"
       CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      MSYSTEM: MINGW64
       GENERATOR: "Ninja"
       BUILDFLAGS: "-v"
       CMAKEARGS: ""
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      MSYSTEM: MINGW64
       GENERATOR: "MSYS Makefiles"
       BUILDFLAGS: "VERBOSE=1"
       CMAKEARGS: ""
       ANACONDA_TESTS_ONLY: "1"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      MSYSTEM: MINGW64
       GENERATOR: "Visual Studio 15 2017 Win64"
       BUILDFLAGS: "/verbosity:normal"
       CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
@@ -46,7 +41,7 @@ environment:
 #  fast_finish: true
 
 init:
-  - set PATH=C:\msys64\%MSYSTEM%\bin;C:\msys64\usr\bin;%PATH%
+  - set PATH=C:\msys64\MINGW64\bin;C:\msys64\usr\bin;%PATH%
   - set PATH=C:\Python36-x64;C:\Python36-x64\Scripts;%PATH%
   # Remove Python 2.7 from path
   - set PATH=%PATH:C:\Python27;=%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,12 +16,6 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       MSYSTEM: MINGW64
-      GENERATOR: "MSYS Makefiles"
-      BUILDFLAGS: "VERBOSE=1"
-      CMAKEARGS: ""
-      ANACONDA_TESTS_ONLY: "1"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      MSYSTEM: MINGW64
       GENERATOR: "Visual Studio 14 2015 Win64"
       BUILDFLAGS: "/verbosity:normal"
       CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
@@ -40,6 +34,12 @@ environment:
       GENERATOR: "Ninja"
       BUILDFLAGS: "-v"
       CMAKEARGS: ""
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      MSYSTEM: MINGW64
+      GENERATOR: "MSYS Makefiles"
+      BUILDFLAGS: "VERBOSE=1"
+      CMAKEARGS: ""
+      ANACONDA_TESTS_ONLY: "1"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       MSYSTEM: MINGW64
       GENERATOR: "Visual Studio 14 2015 Win64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,11 +16,6 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       MSYSTEM: MINGW64
-      GENERATOR: "Visual Studio 14 2015 Win64"
-      BUILDFLAGS: "/verbosity:normal"
-      CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      MSYSTEM: MINGW64
       GENERATOR: "MSYS Makefiles"
       BUILDFLAGS: "VERBOSE=1"
       CMAKEARGS: ""
@@ -39,12 +34,6 @@ environment:
       GENERATOR: "MSYS Makefiles"
       BUILDFLAGS: "VERBOSE=1"
       CMAKEARGS: ""
-      ANACONDA_TESTS_ONLY: "1"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      MSYSTEM: MINGW64
-      GENERATOR: "Visual Studio 14 2015 Win64"
-      BUILDFLAGS: "/verbosity:normal"
-      CMAKEARGS: "-DCMAKE_TOOLCHAIN_FILE=C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
       ANACONDA_TESTS_ONLY: "1"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       MSYSTEM: MINGW64


### PR DESCRIPTION
Most significant change is that only latest VS is tested. Other changes are to get clearer overview on Appveyor without clicking every test lane.