### PR TITLE
Boost on Appveyor. Closes #426 and #427

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,10 +42,8 @@ init:
   - set PATH=%PATH:C:\Python27\Scripts;=%
   # Add Anaconda to PATH
   - set PATH=C:\Deps\conda\Scripts;C:\Deps\conda\library\bin;%PATH%
-  # Add system Boost to PATH, but only for VS generator
-  - if "%GENERATOR%"=="Visual Studio 15 2017 Win64" (
-      set PATH=C:\Libraries\boost_1_67_0\lib64-msvc-14.1;%PATH%
-    )
+  # Add system Boost to PATH
+  - set PATH=C:\Libraries\boost_1_67_0\lib64-msvc-14.1;%PATH%
 
 cache:
   - c:\tools\vcpkg\installed\ -> testing\dependencies\appveyor\install.bat
@@ -71,8 +69,6 @@ before_build:
 build_script:
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv lock"
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
-  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-09/recipe-04'"
-  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-04'"
   - if "%ANACONDA_TESTS_ONLY%"=="1" (
       bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'" &&
       bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,6 +47,8 @@ init:
   - set PATH=%PATH:C:\Python27\Scripts;=%
   # Add Anaconda to PATH
   - set PATH=C:\Deps\conda\Scripts;C:\Deps\conda\library\bin;%PATH%
+  # Add system Boost to PATH
+  - set PATH=C:\Libraries\boost_1_67_0\lib64-msvc-14.1;%PATH%
 
 cache:
   - c:\tools\vcpkg\installed\ -> testing\dependencies\appveyor\install.bat
@@ -72,23 +74,28 @@ before_build:
 build_script:
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv lock"
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
-  - if "%ANACONDA_TESTS_ONLY%"=="1" (
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
-    ) else (
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-10/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-13/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-12/recipe-*'"
-    )
+  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-04'"
+  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-09/recipe-04'"
+  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-03/recipe-08'"
+  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-01'"
+  #- if "%ANACONDA_TESTS_ONLY%"=="1" (
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
+  #  ) else (
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-13/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-10/recipe-0[1-3]'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'" &&
+  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-12/recipe-*'"
+  #  )
+#     bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-10/recipe-04'" &&
 #     bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-0[2-3]'" &&
 
 deploy: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,3 @@
-# See http://msdn.microsoft.com/en-us/library/ms164311.aspx for
-# command-line options to MSBuild.
-
-# Speeding up a Visual Studio build.
-# http://blogs.msdn.com/b/vcblog/archive/2011/01/05/damn-my-vc-project-is-building-slower-in-vs2010-what-do-i-do-now-a-step-by-step-guide.aspx
 version: 'build-{build}-{branch}'
 
 platform: x64
@@ -47,8 +42,10 @@ init:
   - set PATH=%PATH:C:\Python27\Scripts;=%
   # Add Anaconda to PATH
   - set PATH=C:\Deps\conda\Scripts;C:\Deps\conda\library\bin;%PATH%
-  # Add system Boost to PATH
-  - set PATH=C:\Libraries\boost_1_67_0\lib64-msvc-14.1;%PATH%
+  # Add system Boost to PATH, but only for VS generator
+  - if "%GENERATOR%"=="Visual Studio 15 2017 Win64" (
+      set PATH=C:\Libraries\boost_1_67_0\lib64-msvc-14.1;%PATH%
+    )
 
 cache:
   - c:\tools\vcpkg\installed\ -> testing\dependencies\appveyor\install.bat
@@ -74,28 +71,25 @@ before_build:
 build_script:
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv lock"
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
-  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-04'"
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-09/recipe-04'"
-  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-03/recipe-08'"
-  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-01'"
-  #- if "%ANACONDA_TESTS_ONLY%"=="1" (
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
-  #  ) else (
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-13/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-10/recipe-0[1-3]'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'" &&
-  #    bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-12/recipe-*'"
-  #  )
-#     bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-10/recipe-04'" &&
+  - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-04'"
+  - if "%ANACONDA_TESTS_ONLY%"=="1" (
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
+    ) else (
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-03/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-04/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-05/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-06/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-07/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-09/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-10/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-01'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-12/recipe-*'" &&
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-13/recipe-*'"
+    )
 #     bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-0[2-3]'" &&
 
 deploy: off

--- a/chapter-03/recipe-03/cxx-example/CMakeLists.txt
+++ b/chapter-03/recipe-03/cxx-example/CMakeLists.txt
@@ -47,15 +47,6 @@ target_sources(pure-embedding
     Py${PYTHON_VERSION_MAJOR}-pure-embedding.cpp
   )
 
-# workaround for problem with different names of some math
-# functions on Windows MSYS
-if(WIN32 AND (NOT MSVC))
-  target_compile_definitions(pure-embedding
-    PUBLIC
-      "_hypot=hypot"
-    )
-endif()
-
 target_include_directories(pure-embedding
   PRIVATE
     ${PYTHON_INCLUDE_DIRS}

--- a/chapter-03/recipe-03/cxx-example/menu.yml
+++ b/chapter-03/recipe-03/cxx-example/menu.yml
@@ -2,3 +2,7 @@ appveyor-vs:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
     - CMAKE_CONFIGURATION_TYPES: 'Release'
+
+appveyor-msys:
+  definitions:
+    - CMAKE_CXX_FLAGS: '-D_hypot=hypot'

--- a/chapter-03/recipe-08/cxx-example/menu.yml
+++ b/chapter-03/recipe-08/cxx-example/menu.yml
@@ -1,6 +1,7 @@
 appveyor-vs:
   definitions:
-    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
+    - BOOST_ROOT: 'C:\Libraries\boost_1_67_0'
+    - CMAKE_CXX_FLAGS: '-DBOOST_ALL_NO_LIB'  
 
 travis-osx:
   definitions:

--- a/chapter-04/recipe-01/cxx-example/menu.yml
+++ b/chapter-04/recipe-01/cxx-example/menu.yml
@@ -1,6 +1,7 @@
 appveyor-vs:
   definitions:
-    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
+    - BOOST_ROOT: 'C:\Libraries\boost_1_67_0'
+    - CMAKE_CXX_FLAGS: '-DBOOST_ALL_NO_LIB'  
 
 travis-osx:
   definitions:

--- a/chapter-04/recipe-04/cxx-example/menu.yml
+++ b/chapter-04/recipe-04/cxx-example/menu.yml
@@ -1,6 +1,7 @@
 appveyor-vs:
   definitions:
-    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
+    - BOOST_ROOT: 'C:\Libraries\boost_1_67_0'
+    - CMAKE_CXX_FLAGS: '-DBOOST_ALL_NO_LIB'  
 
 travis-osx:
   definitions:

--- a/chapter-09/recipe-03/cxx-example/CMakeLists.txt
+++ b/chapter-09/recipe-03/cxx-example/CMakeLists.txt
@@ -29,15 +29,6 @@ set_source_files_properties(account.pyx PROPERTIES CYTHON_IS_CXX TRUE)
 # create python module
 cython_add_module(account account.pyx account.cpp)
 
-# workaround for problem with different names of some math
-# functions on Windows MSYS
-if(WIN32 AND (NOT MSVC))
-  target_compile_definitions(account
-    PRIVATE
-      "_hypot=hypot"
-    )
-endif()
-
 # location of account.hpp
 target_include_directories(account
   PRIVATE

--- a/chapter-09/recipe-03/cxx-example/menu.yml
+++ b/chapter-09/recipe-03/cxx-example/menu.yml
@@ -9,3 +9,4 @@ appveyor-vs:
 appveyor-msys:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
+    - CMAKE_CXX_FLAGS: '-D_hypot=hypot'

--- a/chapter-09/recipe-04/cxx-example/CMakeLists.txt
+++ b/chapter-09/recipe-04/cxx-example/CMakeLists.txt
@@ -51,15 +51,6 @@ add_library(account
     account.cpp
   )
 
-# workaround for problem with different names of some math
-# functions on Windows MSYS
-if(WIN32 AND (NOT MSVC))
-  target_compile_definitions(account
-    PUBLIC
-      "_hypot=hypot"
-    )
-endif()
-
 target_link_libraries(account
   PUBLIC
     Boost::${_boost_component_found}

--- a/chapter-09/recipe-04/cxx-example/CMakeLists.txt
+++ b/chapter-09/recipe-04/cxx-example/CMakeLists.txt
@@ -34,9 +34,6 @@ list(
 set(_boost_component_found "")
 
 foreach(_component IN ITEMS ${_components})
-  set(Boost_USE_STATIC_LIBS ON)
-  set(Boost_USE_MULTITHREADED ON)
-  set(Boost_USE_STATIC_RUNTIME ON)
   find_package(Boost COMPONENTS ${_component})
   if(Boost_FOUND)
     set(_boost_component_found ${_component})

--- a/chapter-09/recipe-04/cxx-example/menu.yml
+++ b/chapter-09/recipe-04/cxx-example/menu.yml
@@ -13,7 +13,10 @@ appveyor-vs:
 appveyor-msys:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
+    - Boost_USE_STATIC_LIBS: 'ON'
+    - Boost_USE_MULTITHREADED: 'ON'
     - Boost_USE_STATIC_RUNTIME: 'ON'
+    - CMAKE_CXX_FLAGS: '-D_hypot=hypot'
 
 travis-osx:
   definitions:

--- a/chapter-09/recipe-04/cxx-example/menu.yml
+++ b/chapter-09/recipe-04/cxx-example/menu.yml
@@ -2,7 +2,8 @@ appveyor-vs:
   env:
     - VERBOSE_OUTPUT: 'True'
   definitions:
-    - BOOST_ROOT: 'C:\tools\vcpkg\installed\x64-windows'
+    - BOOST_ROOT: 'C:\Libraries\boost_1_67_0'
+    - CMAKE_CXX_FLAGS: '-DBOOST_ALL_NO_LIB'  
     - CMAKE_BUILD_TYPE: 'Release'
     - CMAKE_CONFIGURATION_TYPES: 'Release'
   # fails because packaged boost only provides python27
@@ -12,6 +13,7 @@ appveyor-vs:
 appveyor-msys:
   definitions:
     - CMAKE_BUILD_TYPE: 'Release'
+    - Boost_USE_STATIC_RUNTIME: 'ON'
 
 travis-osx:
   definitions:

--- a/chapter-09/recipe-05/cxx-example/account/CMakeLists.txt
+++ b/chapter-09/recipe-05/cxx-example/account/CMakeLists.txt
@@ -23,15 +23,6 @@ add_library(account
     account.cpp
   )
 
-# workaround for problem with different names of some math
-# functions on Windows MSYS
-if(WIN32 AND (NOT MSVC))
-  target_compile_definitions(account
-    PUBLIC
-      "_hypot=hypot"
-    )
-endif()
-
 target_link_libraries(account
   PUBLIC
     pybind11::module

--- a/chapter-09/recipe-05/cxx-example/menu.yml
+++ b/chapter-09/recipe-05/cxx-example/menu.yml
@@ -4,5 +4,7 @@ targets:
 # fetchcontent on msys never completes
 # not sure why
 appveyor-msys:
+  definitions:
+    - CMAKE_CXX_FLAGS: '-D_hypot=hypot'
   skip_generators:
     - 'MSYS Makefiles'

--- a/chapter-11/recipe-02/cxx-example/account/CMakeLists.txt
+++ b/chapter-11/recipe-02/cxx-example/account/CMakeLists.txt
@@ -18,15 +18,6 @@ add_library(account
     account.cpp
   )
 
-# workaround for problem with different names of some math
-# functions on Windows MSYS
-if(WIN32 AND (NOT MSVC))
-  target_compile_definitions(account
-    PUBLIC
-      "_hypot=hypot"
-    )
-endif()
-
 target_link_libraries(account
   PUBLIC
     pybind11::module

--- a/chapter-11/recipe-02/cxx-example/menu.yml
+++ b/chapter-11/recipe-02/cxx-example/menu.yml
@@ -1,0 +1,3 @@
+appveyor-msys:
+  definitions:
+    - CMAKE_CXX_FLAGS: '-D_hypot=hypot'

--- a/testing/collect_tests.py
+++ b/testing/collect_tests.py
@@ -51,7 +51,7 @@ def run_command(*, step, command, expect_failure):
     # Stream stdout in verbose mode only
     stdout_streamer = functools.partial(streamer, verbose=verbose_output())
     # stdout starts with the command we want to execute
-    stdout = stdout_streamer(command)
+    stdout = stdout_streamer(command, end='\n')
     # Stream stderr always
     stderr_streamer = functools.partial(streamer, file_handle=sys.stderr)
     stderr = ''

--- a/testing/dependencies/appveyor/install.bat
+++ b/testing/dependencies/appveyor/install.bat
@@ -28,7 +28,7 @@ if "%nonVSGenerator%"=="true" (
   echo "Using VS generator %GENERATOR%"
   echo "Let's get VcPkg working"
 
-  vcpkg install boost-filesystem boost-system boost-test boost-python zeromq eigen3 --triplet x64-windows
+  vcpkg install zeromq eigen3 --triplet x64-windows
   cd c:\tools\vcpkg
   vcpkg integrate install
   cd %APPVEYOR_BUILD_FOLDER%

--- a/testing/menu.yml
+++ b/testing/menu.yml
@@ -43,6 +43,8 @@ travis-osx:
     - 'DIE_HARD': 'True'
 
 local:
+  env:
+    - 'VERBOSE_OUTPUT': 'True'
   definitions:
     - CMAKE_C_COMPILER: 'gcc'
     - CMAKE_CXX_COMPILER: 'g++'


### PR DESCRIPTION
Uses Boost pre-installed on Appveyor and removes some Windows specific flags from `CMakeLists.txt`. This should reduce startup time, especially if the cache has to be regenerated, cache size and cache upload time.

Takes over and completes #432 

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
