### PR TITLE
size_t must be prefix with std::

### DIFF
--- a/chapter-06/recipe-03/cxx-example/generate.py
+++ b/chapter-06/recipe-03/cxx-example/generate.py
@@ -22,7 +22,7 @@ primes = (number for number in numbers if is_prime[number])
 with open(output_file_name, 'w') as f:
     f.write('#pragma once\n')
     f.write('#include <vector>\n\n')
-    f.write('const size_t max_number = {0};\n'.format(max_number))
+    f.write('const std::size_t max_number = {0};\n'.format(max_number))
     f.write('std::vector<int> & primes() {\n')
     f.write('  static std::vector<int> primes;\n')
     for number in primes:


### PR DESCRIPTION
Generated file primes.hpp is missing std:: prefix before size_t.
Without this modification on my side I get:

```
In file included from /home/enoulard/Research/CMake/cmake-cookbook/chapter-06/recipe-03/cxx-example/example.cpp:1:0:
/home/enoulard/Research/CMake/cmake-cookbook/chapter-06/recipe-03/cxx-example/b/generated/primes.hpp:4:7: error: ‘size_t’ does not name a type
 const size_t max_number = 100;
       ^~~~~~
```
