### PR TITLE
Format CMake

### DIFF
--- a/chapter-07/recipe-07/cxx-example/external/CMakeLists.txt
+++ b/chapter-07/recipe-07/cxx-example/external/CMakeLists.txt
@@ -1,15 +1,13 @@
 add_library(conversion "")
 
-target_sources(
-  conversion
+target_sources(conversion
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/conversion.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/conversion.hpp
   )
 
-target_include_directories(
-  conversion
+target_include_directories(conversion
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-07/cxx-example/src/evolution/CMakeLists.txt
+++ b/chapter-07/recipe-07/cxx-example/src/evolution/CMakeLists.txt
@@ -1,15 +1,13 @@
 add_library(evolution "")
 
-target_sources(
-  evolution
+target_sources(evolution
   PRIVATE
     evolution.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/evolution.hpp
   )
 
-target_include_directories(
-  evolution
+target_include_directories(evolution
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-07/cxx-example/src/initial/CMakeLists.txt
+++ b/chapter-07/recipe-07/cxx-example/src/initial/CMakeLists.txt
@@ -1,15 +1,13 @@
 add_library(initial "")
 
-target_sources(
-  initial
+target_sources(initial
   PRIVATE
     initial.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/initial.hpp
   )
 
-target_include_directories(
-  initial
+target_include_directories(initial
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-07/cxx-example/src/io/CMakeLists.txt
+++ b/chapter-07/recipe-07/cxx-example/src/io/CMakeLists.txt
@@ -1,15 +1,13 @@
 add_library(io "")
 
-target_sources(
-  io
+target_sources(io
   PRIVATE
     io.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/io.hpp
   )
 
-target_include_directories(
-  io
+target_include_directories(io
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-07/cxx-example/src/parser/CMakeLists.txt
+++ b/chapter-07/recipe-07/cxx-example/src/parser/CMakeLists.txt
@@ -1,15 +1,13 @@
 add_library(parser "")
 
-target_sources(
-  parser
+target_sources(parser
   PRIVATE
     parser.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/parser.hpp
   )
 
-target_include_directories(
-  parser
+target_include_directories(parser
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-08/cxx-example/src/evolution/CMakeLists.txt
+++ b/chapter-07/recipe-08/cxx-example/src/evolution/CMakeLists.txt
@@ -1,27 +1,23 @@
-target_sources(
-  automaton
+target_sources(automaton
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/evolution.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/evolution.hpp
   )
 
-target_include_directories(
-  automaton
+target_include_directories(automaton
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )
 
-target_sources(
-  evolution
+target_sources(evolution
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/evolution.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/evolution.hpp
   )
 
-target_include_directories(
-  evolution
+target_include_directories(evolution
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-08/cxx-example/src/initial/CMakeLists.txt
+++ b/chapter-07/recipe-08/cxx-example/src/initial/CMakeLists.txt
@@ -1,13 +1,11 @@
-target_sources(
-  automaton
+target_sources(automaton
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/initial.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/initial.hpp
   )
 
-target_include_directories(
-  automaton
+target_include_directories(automaton
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-08/cxx-example/src/io/CMakeLists.txt
+++ b/chapter-07/recipe-08/cxx-example/src/io/CMakeLists.txt
@@ -1,13 +1,11 @@
-target_sources(
-  automaton
+target_sources(automaton
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/io.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/io.hpp
   )
 
-target_include_directories(
-  automaton
+target_include_directories(automaton
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/chapter-07/recipe-08/cxx-example/src/parser/CMakeLists.txt
+++ b/chapter-07/recipe-08/cxx-example/src/parser/CMakeLists.txt
@@ -1,13 +1,11 @@
-target_sources(
-  automaton
+target_sources(automaton
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/parser.cpp
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/parser.hpp
   )
 
-target_include_directories(
-  automaton
+target_include_directories(automaton
   PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
   )


### PR DESCRIPTION
Some `target_` commands were not indented as per our convention. TC amended already.

## Status
- [x]  Ready to go
