### PR TITLE
Better install prefixes

### DIFF
--- a/chapter-10/recipe-01/cxx-example/menu.yml
+++ b/chapter-10/recipe-01/cxx-example/menu.yml
@@ -1,34 +1,34 @@
 appveyor-vs:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-01
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-01
 
 appveyor-msys:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-01
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-01
 
 travis-linux:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-01
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-01
 
 travis-osx:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-01
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-01
 
 circle-intel:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-01
 
 # Fails to generate imported target for UUID
 circle-pgi:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-01
   skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 
 local:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-01
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-01
 
 targets:
   - test

--- a/chapter-10/recipe-02/cxx-example/menu.yml
+++ b/chapter-10/recipe-02/cxx-example/menu.yml
@@ -1,34 +1,34 @@
 appveyor-vs:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-02
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-02
 
 appveyor-msys:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-02
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-02
 
 travis-linux:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-02
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-02
 
 travis-osx:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-02
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-02
 
 circle-intel:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-02
 
 # Fails to generate imported target for UUID
 circle-pgi:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-02
   skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 
 local:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-02
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-02
 
 targets:
   - test

--- a/chapter-10/recipe-03/cxx-example/menu.yml
+++ b/chapter-10/recipe-03/cxx-example/menu.yml
@@ -1,34 +1,34 @@
 appveyor-vs:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-03
 
 appveyor-msys:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-03
 
 travis-linux:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-03
 
 travis-osx:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-03
 
 circle-intel:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-03
 
 # Fails to generate imported target for UUID
 circle-pgi:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-03
   skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 
 local:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-03
 
 targets:
   - install

--- a/chapter-10/recipe-04/cxx-example/menu.yml
+++ b/chapter-10/recipe-04/cxx-example/menu.yml
@@ -1,34 +1,34 @@
 appveyor-vs:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-04
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-04
 
 appveyor-msys:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-04
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-04
 
 travis-linux:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-04
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-04
 
 travis-osx:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-04
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-04
 
 circle-intel:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-04
 
 # Fails to generate imported target for UUID
 circle-pgi:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-03
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-04
   skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 
 local:
   definitions:
-    - CMAKE_INSTALL_PREFIX: $HOME/Software/recipe-04
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-10/recipe-04
 
 targets:
   - test

--- a/chapter-11/recipe-01/cxx-example/menu.yml
+++ b/chapter-11/recipe-01/cxx-example/menu.yml
@@ -10,3 +10,7 @@ circle-pgi:
   skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
+
+local:
+  definitions:
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-11/recipe-01

--- a/chapter-13/recipe-01/cxx-example/menu.yml
+++ b/chapter-13/recipe-01/cxx-example/menu.yml
@@ -10,3 +10,8 @@ travis-linux:
   definitions:
     - CMAKE_TOOLCHAIN_FILE: $TRAVIS_BUILD_DIR/chapter-13/toolchain-travis.cmake
     - CMAKE_INSTALL_PREFIX: $TRAVIS_BUILD_DIR/../install
+
+local:
+  definitions:
+    - CMAKE_TOOLCHAIN_FILE: $PWD/chapter-13/toolchain-travis.cmake
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-13/recipe-01

--- a/chapter-13/recipe-02/cxx-example/menu.yml
+++ b/chapter-13/recipe-02/cxx-example/menu.yml
@@ -10,3 +10,8 @@ travis-linux:
   definitions:
     - CMAKE_TOOLCHAIN_FILE: $TRAVIS_BUILD_DIR/chapter-13/toolchain-travis.cmake
     - CMAKE_INSTALL_PREFIX: $TRAVIS_BUILD_DIR/../install
+
+local:
+  definitions:
+    - CMAKE_TOOLCHAIN_FILE: $PWD/chapter-13/toolchain-travis.cmake
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-13/recipe-02-cxx

--- a/chapter-13/recipe-02/fortran-example/menu.yml
+++ b/chapter-13/recipe-02/fortran-example/menu.yml
@@ -25,3 +25,6 @@ travis-linux:
 local:
   failing_generators:
     - 'Ninja'
+  definitions:
+    - CMAKE_TOOLCHAIN_FILE: $PWD/chapter-13/toolchain-travis.cmake
+    - CMAKE_INSTALL_PREFIX: $HOME/Software/chapter-13/recipe-02-fortran


### PR DESCRIPTION
This lets `pipenv run python testing/collect_tests.py` not panic when the `local` stanza of the `menu.yml` is executed (e.g. on the Docker image)
@bast Chapter 13 tries to install to `/usr/local` and I wasn't sure how to set the install prefix and location of toolchain. I can adjust the PR aftewards to make it complete.

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
