### PR TITLE
use "Previous Visual Studio 2017" image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ build:
   parallel: true
 
 image:
-  - Visual Studio 2017
+  - Previous Visual Studio 2017
 
 environment:
   # Create expected SHELL variable for pipenv.


### PR DESCRIPTION
this is to hopefull work around a timeout problem
and not use the latest build worker image