### PR TITLE
Add cmake doc link to abstract chapters 01-04 and 11--14 

### DIFF
--- a/chapter-01/recipe-03/README.md
+++ b/chapter-01/recipe-03/README.md
@@ -1,7 +1,7 @@
 # Building and linking static and shared libraries
 
 We demonstrate how to build a set of source files into shared or static libraries.
-An example is also given that demonstrates the use of the CMake `OBJECT` library
+An example is also given that demonstrates the use of the CMake [`OBJECT` library](https://cmake.org/cmake/help/latest/command/add_library.html#object-libraries)
 facility to build _both_ the shared and static variant.
 The latter example will be revisited in [Recipe 2 in Chapter 10](../../chapter-10/recipe-02/README.md)
 

--- a/chapter-01/recipe-03/abstract.md
+++ b/chapter-01/recipe-03/abstract.md
@@ -1,4 +1,4 @@
 We demonstrate how to build a set of source files into shared or static libraries.
-An example is also given that demonstrates the use of the CMake `OBJECT` library
+An example is also given that demonstrates the use of the CMake [`OBJECT` library](https://cmake.org/cmake/help/latest/command/add_library.html#object-libraries)
 facility to build _both_ the shared and static variant.
 The latter example will be revisited in [Recipe 2 in Chapter 10](../../chapter-10/recipe-02/README.md)

--- a/chapter-01/recipe-04/README.md
+++ b/chapter-01/recipe-04/README.md
@@ -1,6 +1,6 @@
 # Controlling compilation with conditionals
 
-This recipe demonstrates how to use the `if-else-endif` conditional construct in `CMakeLists.txt`.
+This recipe demonstrates how to use the [`if-else-endif`](https://cmake.org/cmake/help/latest/command/if.html) conditional construct in `CMakeLists.txt`.
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-01/recipe-04/abstract.md
+++ b/chapter-01/recipe-04/abstract.md
@@ -1,1 +1,1 @@
-This recipe demonstrates how to use the `if-else-endif` conditional construct in `CMakeLists.txt`.
+This recipe demonstrates how to use the [`if-else-endif`](https://cmake.org/cmake/help/latest/command/if.html) conditional construct in `CMakeLists.txt`.

--- a/chapter-01/recipe-05/README.md
+++ b/chapter-01/recipe-05/README.md
@@ -1,7 +1,7 @@
 # Presenting options to the user
 
 We will demonstrate how to make aspects of the build system configurable by
-exposing options to the user with the `option` command.
+exposing options to the user with the [`option`](https://cmake.org/cmake/help/latest/command/option.html) command.
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-01/recipe-05/abstract.md
+++ b/chapter-01/recipe-05/abstract.md
@@ -1,2 +1,2 @@
 We will demonstrate how to make aspects of the build system configurable by
-exposing options to the user with the `option` command.
+exposing options to the user with the [`option`](https://cmake.org/cmake/help/latest/command/option.html) command.

--- a/chapter-01/recipe-06/README.md
+++ b/chapter-01/recipe-06/README.md
@@ -1,7 +1,7 @@
 # Specifying the compiler
 
 This recipe explains how to set the compiler for the project. We will discuss
-the `CMAKE_<LANG>_COMPILER` CMake options.
+the [`CMAKE_<LANG>_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) CMake options.
 
 
 - [example](example/)

--- a/chapter-01/recipe-06/abstract.md
+++ b/chapter-01/recipe-06/abstract.md
@@ -1,2 +1,2 @@
 This recipe explains how to set the compiler for the project. We will discuss
-the `CMAKE_<LANG>_COMPILER` CMake options.
+the [`CMAKE_<LANG>_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) CMake options.

--- a/chapter-01/recipe-07/README.md
+++ b/chapter-01/recipe-07/README.md
@@ -1,6 +1,6 @@
 # Switching the build type
 
-We will discuss the CMake options `CMAKE_BUILD_TYPE` and `CMAKE_CONFIGURATION_TYPES`
+We will discuss the CMake options [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html) and [`CMAKE_CONFIGURATION_TYPES`](https://cmake.org/cmake/help/latest/variable/CMAKE_CONFIGURATION_TYPES.html)
 and the configurations (`Debug`, `Release`, and so forth) CMake offers.
 
 

--- a/chapter-01/recipe-07/abstract.md
+++ b/chapter-01/recipe-07/abstract.md
@@ -1,2 +1,2 @@
-We will discuss the CMake options `CMAKE_BUILD_TYPE` and `CMAKE_CONFIGURATION_TYPES`
+We will discuss the CMake options [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html) and [`CMAKE_CONFIGURATION_TYPES`](https://cmake.org/cmake/help/latest/variable/CMAKE_CONFIGURATION_TYPES.html)
 and the configurations (`Debug`, `Release`, and so forth) CMake offers.

--- a/chapter-01/recipe-08/README.md
+++ b/chapter-01/recipe-08/README.md
@@ -1,7 +1,7 @@
 # Controlling compiler flags
 
 This recipe shows how to set compiler flags for targets using
-`target_compile_options()`. The compiler options set are only valid for GCC and
+[`target_compile_options()`](https://cmake.org/cmake/help/latest/command/target_compile_options.html). The compiler options set are only valid for GCC and
 Clang, thus building this project **fails** on Visual Studio.
 
 

--- a/chapter-01/recipe-08/abstract.md
+++ b/chapter-01/recipe-08/abstract.md
@@ -1,3 +1,3 @@
 This recipe shows how to set compiler flags for targets using
-`target_compile_options()`. The compiler options set are only valid for GCC and
+[`target_compile_options()`](https://cmake.org/cmake/help/latest/command/target_compile_options.html). The compiler options set are only valid for GCC and
 Clang, thus building this project **fails** on Visual Studio.

--- a/chapter-01/recipe-10/README.md
+++ b/chapter-01/recipe-10/README.md
@@ -1,6 +1,6 @@
 # Using control flow constructs
 
-This recipe shows how to use loop construct `foreach-endforeach` in CMake.
+This recipe shows how to use loop construct [`foreach-endforeach`](https://cmake.org/cmake/help/latest/command/foreach.html) in CMake.
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-01/recipe-10/abstract.md
+++ b/chapter-01/recipe-10/abstract.md
@@ -1,1 +1,1 @@
-This recipe shows how to use loop construct `foreach-endforeach` in CMake.
+This recipe shows how to use loop construct [`foreach-endforeach`](https://cmake.org/cmake/help/latest/command/foreach.html) in CMake.

--- a/chapter-02/recipe-01/README.md
+++ b/chapter-02/recipe-01/README.md
@@ -5,5 +5,4 @@ with an example that does not require compilation of any source code. For
 simplicity, we only consider the configuration step.
 
 
-- [cxx-example](cxx-example/)
 - [example](example/)

--- a/chapter-02/recipe-01/README.md
+++ b/chapter-02/recipe-01/README.md
@@ -5,4 +5,5 @@ with an example that does not require compilation of any source code. For
 simplicity, we only consider the configuration step.
 
 
+- [cxx-example](cxx-example/)
 - [example](example/)

--- a/chapter-02/recipe-05/README.md
+++ b/chapter-02/recipe-05/README.md
@@ -1,7 +1,7 @@
 # Discovering the host processor instruction set
 
 In this recipe, we discuss how to discover the host processor instruction set
-with the help of CMake. The detected host system information can be used to
+with the help of CMake. The detected [host system information](https://cmake.org/cmake/help/latest/command/cmake_host_system_information.html) can be used to
 either set corresponding compiler flags or to implement optional compilation of
 sources or source code generation depending on the host system.
 

--- a/chapter-02/recipe-05/abstract.md
+++ b/chapter-02/recipe-05/abstract.md
@@ -1,4 +1,4 @@
 In this recipe, we discuss how to discover the host processor instruction set
-with the help of CMake. The detected host system information can be used to
+with the help of CMake. The detected [host system information](https://cmake.org/cmake/help/latest/command/cmake_host_system_information.html) can be used to
 either set corresponding compiler flags or to implement optional compilation of
 sources or source code generation depending on the host system.

--- a/chapter-02/recipe-06/README.md
+++ b/chapter-02/recipe-06/README.md
@@ -1,7 +1,7 @@
 # Enabling vectorization for the Eigen library
 
 This recipe shows how to enable vectorization to speed up a simple executable
-using the Eigen C++ library for linear algebra.
+using the [Eigen C++ library](http://eigen.tuxfamily.org) for linear algebra.
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-02/recipe-06/abstract.md
+++ b/chapter-02/recipe-06/abstract.md
@@ -1,2 +1,2 @@
 This recipe shows how to enable vectorization to speed up a simple executable
-using the Eigen C++ library for linear algebra.
+using the [Eigen C++ library](http://eigen.tuxfamily.org) for linear algebra.

--- a/chapter-03/recipe-01/README.md
+++ b/chapter-03/recipe-01/README.md
@@ -1,6 +1,6 @@
 # Detecting the Python interpreter
 
-We will introduce the `find_package` CMake command and use it to detect a
+We will introduce the [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) CMake command and use it to detect a
 working Python interpreter on the system.
 
 

--- a/chapter-03/recipe-01/abstract.md
+++ b/chapter-03/recipe-01/abstract.md
@@ -1,2 +1,2 @@
-We will introduce the `find_package` CMake command and use it to detect a
+We will introduce the [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) CMake command and use it to detect a
 working Python interpreter on the system.

--- a/chapter-03/recipe-02/README.md
+++ b/chapter-03/recipe-02/README.md
@@ -1,7 +1,7 @@
 # Detecting the Python library
 
 This recipe builds an executable embedding the Python interpreter. We will use
-`find_package` to find the Python development headers and library.
+[`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) to find the Python development headers and library.
 
 Code example copy-pasted from the Python docs on embedding https://docs.python.org/3.5/extending/embedding.html
 

--- a/chapter-03/recipe-02/abstract.md
+++ b/chapter-03/recipe-02/abstract.md
@@ -1,4 +1,4 @@
 This recipe builds an executable embedding the Python interpreter. We will use
-`find_package` to find the Python development headers and library.
+[`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) to find the Python development headers and library.
 
 Code example copy-pasted from the Python docs on embedding https://docs.python.org/3.5/extending/embedding.html

--- a/chapter-03/recipe-03/README.md
+++ b/chapter-03/recipe-03/README.md
@@ -2,8 +2,8 @@
 
 This example will embed a Python interpreter into a C++ executable and run a
 custom Python script.
-The Python script uses Numpy and we will show how to find this module with CMake
-with help of `find_package_handle_standard_args`.
+The Python script uses [Numpy](http://www.numpy.org/) and we will show how to find this module with CMake
+with help of [`find_package_handle_standard_args`](https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html).
 
 To test run: `./pure-embedding use_numpy print_ones 15 34`
 

--- a/chapter-03/recipe-03/abstract.md
+++ b/chapter-03/recipe-03/abstract.md
@@ -1,6 +1,6 @@
 This example will embed a Python interpreter into a C++ executable and run a
 custom Python script.
-The Python script uses Numpy and we will show how to find this module with CMake
-with help of `find_package_handle_standard_args`.
+The Python script uses [Numpy](http://www.numpy.org/) and we will show how to find this module with CMake
+with help of [`find_package_handle_standard_args`](https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html).
 
 To test run: `./pure-embedding use_numpy print_ones 15 34`

--- a/chapter-03/recipe-05/README.md
+++ b/chapter-03/recipe-05/README.md
@@ -1,7 +1,7 @@
 # Detecting the OpenMP parallel environment
 
 We will show how to detect support for the OpenMP shared-memory parallelism
-standard. Usage of CMake `IMPORTED` libraries is shown. Examples are given for
+standard. Usage of CMake [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) is shown. Examples are given for
 both C++ and Fortran using CMake 3.9 or higher. The `cxx-example-3.5` and
 `fortran-example-3.5` show how to attain the same goal with a lower version of
 CMake.

--- a/chapter-03/recipe-05/abstract.md
+++ b/chapter-03/recipe-05/abstract.md
@@ -1,5 +1,5 @@
 We will show how to detect support for the OpenMP shared-memory parallelism
-standard. Usage of CMake `IMPORTED` libraries is shown. Examples are given for
+standard. Usage of CMake [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) is shown. Examples are given for
 both C++ and Fortran using CMake 3.9 or higher. The `cxx-example-3.5` and
 `fortran-example-3.5` show how to attain the same goal with a lower version of
 CMake.

--- a/chapter-03/recipe-06/README.md
+++ b/chapter-03/recipe-06/README.md
@@ -1,7 +1,7 @@
 # Detecting the MPI parallel environment
 
 We will show how to detect support for MPI distributed-memory parallelism
-standard. Usage of CMake `IMPORTED` libraries is shown.
+standard. Usage of CMake [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) is shown.
 Examples are given for both C++ and C using CMake 3.9 or higher.
 The `c-example-3.5` show how to attain the same goal with a lower version of
 CMake.

--- a/chapter-03/recipe-06/abstract.md
+++ b/chapter-03/recipe-06/abstract.md
@@ -1,5 +1,5 @@
 We will show how to detect support for MPI distributed-memory parallelism
-standard. Usage of CMake `IMPORTED` libraries is shown.
+standard. Usage of CMake [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) is shown.
 Examples are given for both C++ and C using CMake 3.9 or higher.
 The `c-example-3.5` show how to attain the same goal with a lower version of
 CMake.

--- a/chapter-03/recipe-07/README.md
+++ b/chapter-03/recipe-07/README.md
@@ -1,8 +1,8 @@
 # Detecting the Eigen library
 
-Show how to use the Eigen library with OpenMP threading and optionally linking
+Show how to use the [Eigen library](http://eigen.tuxfamily.org) with [OpenMP](https://www.openmp.org/) threading and optionally linking
 to BLAS/LAPACK.
-Usage of CMake `IMPORTED` libraries is shown for CMake 3.9 or higher.
+Usage of CMake [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) is shown for CMake 3.9 or higher.
 The `cxx-example-3.5` folder shows how to attain the same goal with older
 versions of CMake.
 

--- a/chapter-03/recipe-07/abstract.md
+++ b/chapter-03/recipe-07/abstract.md
@@ -1,5 +1,5 @@
-Show how to use the Eigen library with OpenMP threading and optionally linking
+Show how to use the [Eigen library](http://eigen.tuxfamily.org) with [OpenMP](https://www.openmp.org/) threading and optionally linking
 to BLAS/LAPACK.
-Usage of CMake `IMPORTED` libraries is shown for CMake 3.9 or higher.
+Usage of CMake [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) is shown for CMake 3.9 or higher.
 The `cxx-example-3.5` folder shows how to attain the same goal with older
 versions of CMake.

--- a/chapter-03/recipe-08/README.md
+++ b/chapter-03/recipe-08/README.md
@@ -1,7 +1,7 @@
 # Detecting the Boost libraries
 
-This recipe shows how to find the Boost C++ libraries and how these are
-conveniently wrapped into `IMPORTED` libraries in CMake.
+This recipe shows how to find the [Boost C++](https://www.boost.org/) libraries and how these are
+conveniently wrapped into [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) in CMake.
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-03/recipe-08/abstract.md
+++ b/chapter-03/recipe-08/abstract.md
@@ -1,2 +1,2 @@
-This recipe shows how to find the Boost C++ libraries and how these are
-conveniently wrapped into `IMPORTED` libraries in CMake.
+This recipe shows how to find the [Boost C++](https://www.boost.org/) libraries and how these are
+conveniently wrapped into [`IMPORTED` libraries](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) in CMake.

--- a/chapter-03/recipe-09/README.md
+++ b/chapter-03/recipe-09/README.md
@@ -1,8 +1,8 @@
 # Detecting external libraries: I. Using `pkg-config`
 
-This recipe shows how to detect the ZeroMQ library using CMake and `pkg-config`.
+This recipe shows how to detect the [ZeroMQ library](http://zeromq.org/) using CMake and `pkg-config`.
 The recipe works on Unix-like systems, such as GNU/Linux and macOS.
-For CMake 3.6 and higher, an `IMPORTED` library can be used, but an example
+For CMake 3.6 and higher, an [`IMPORTED` library](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) can be used, but an example
 for older versions of CMake is also shown.
 
 

--- a/chapter-03/recipe-09/abstract.md
+++ b/chapter-03/recipe-09/abstract.md
@@ -1,4 +1,4 @@
-This recipe shows how to detect the ZeroMQ library using CMake and `pkg-config`.
+This recipe shows how to detect the [ZeroMQ library](http://zeromq.org/) using CMake and `pkg-config`.
 The recipe works on Unix-like systems, such as GNU/Linux and macOS.
-For CMake 3.6 and higher, an `IMPORTED` library can be used, but an example
+For CMake 3.6 and higher, an [`IMPORTED` library](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) can be used, but an example
 for older versions of CMake is also shown.

--- a/chapter-04/recipe-03/README.md
+++ b/chapter-04/recipe-03/README.md
@@ -3,7 +3,7 @@
 In this recipe, we demonstrate how to implement unit testing using the [Google
 Test](https://github.com/google/googletest) framework, with the help of CMake.
 
-We will use `FetchContent` to download a well-defined version of the Google
+We will use [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) to download a well-defined version of the Google
 Test sources at configure time, and then build the framework and link against
 it.
 

--- a/chapter-04/recipe-03/abstract.md
+++ b/chapter-04/recipe-03/abstract.md
@@ -1,6 +1,6 @@
 In this recipe, we demonstrate how to implement unit testing using the [Google
 Test](https://github.com/google/googletest) framework, with the help of CMake.
 
-We will use `FetchContent` to download a well-defined version of the Google
+We will use [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) to download a well-defined version of the Google
 Test sources at configure time, and then build the framework and link against
 it.

--- a/chapter-07/recipe-05/README.md
+++ b/chapter-07/recipe-05/README.md
@@ -3,4 +3,3 @@
 Abstract to be written ...
 
 - [example](example/)
-- [fortran-example](fortran-example/)

--- a/chapter-07/recipe-05/README.md
+++ b/chapter-07/recipe-05/README.md
@@ -3,3 +3,4 @@
 Abstract to be written ...
 
 - [example](example/)
+- [fortran-example](fortran-example/)

--- a/chapter-07/recipe-06/README.md
+++ b/chapter-07/recipe-06/README.md
@@ -2,4 +2,5 @@
 
 Abstract to be written ...
 
+- [cxx-example](cxx-example/)
 - [example](example/)

--- a/chapter-07/recipe-06/README.md
+++ b/chapter-07/recipe-06/README.md
@@ -2,5 +2,4 @@
 
 Abstract to be written ...
 
-- [cxx-example](cxx-example/)
 - [example](example/)

--- a/chapter-11/recipe-02/README.md
+++ b/chapter-11/recipe-02/README.md
@@ -1,8 +1,8 @@
 # Distributing a C++/Python project built with CMake/pybind11 via PyPI
 
 We discuss how to package a Python project with compiled portions written in C++
-for distribution on the Python Package Index (PyPI)
-We use pybind11 to create the C++/Python bindings.
+for distribution on the [Python Package Index](https://pypi.org/) (PyPI)
+We use [pybind11](https://github.com/pybind/pybind11) to create the C++/Python bindings.
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-11/recipe-02/abstract.md
+++ b/chapter-11/recipe-02/abstract.md
@@ -1,3 +1,3 @@
 We discuss how to package a Python project with compiled portions written in C++
-for distribution on the Python Package Index (PyPI)
-We use pybind11 to create the C++/Python bindings.
+for distribution on the [Python Package Index](https://pypi.org/) (PyPI)
+We use [pybind11](https://github.com/pybind/pybind11) to create the C++/Python bindings.

--- a/chapter-11/recipe-03/README.md
+++ b/chapter-11/recipe-03/README.md
@@ -1,7 +1,7 @@
 # Distributing a C/Fortran/Python project built with CMake/CFFI via PyPI
 
 We discuss how to package a Python project with compiled portions written in
-either C++ or Fortran for distribution on the Python Package Index (PyPI)
+either C++ or Fortran for distribution on the [Python Package Index](https://pypi.org) (PyPI)
 We use CFFI to create the Python bindings.
 
 

--- a/chapter-11/recipe-03/abstract.md
+++ b/chapter-11/recipe-03/abstract.md
@@ -1,3 +1,3 @@
 We discuss how to package a Python project with compiled portions written in
-either C++ or Fortran for distribution on the Python Package Index (PyPI)
+either C++ or Fortran for distribution on the [Python Package Index](https://pypi.org) (PyPI)
 We use CFFI to create the Python bindings.

--- a/chapter-11/recipe-04/README.md
+++ b/chapter-11/recipe-04/README.md
@@ -1,6 +1,6 @@
 # Distributing a simple project as Conda package
 
-This recipe shows how to compile a small C++ project as a redistributable Conda package.
+This recipe shows how to compile a small C++ project as a redistributable [Conda](https://conda.io) package.
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-11/recipe-04/abstract.md
+++ b/chapter-11/recipe-04/abstract.md
@@ -1,1 +1,1 @@
-This recipe shows how to compile a small C++ project as a redistributable Conda package.
+This recipe shows how to compile a small C++ project as a redistributable [Conda](https://conda.io) package.

--- a/chapter-11/recipe-05/README.md
+++ b/chapter-11/recipe-05/README.md
@@ -1,6 +1,6 @@
 # Distributing a project with dependencies as Conda package
 
-We show how to package a C++ executable depending on the MKL linear algebra libraries using Conda.
+We show how to package a C++ executable depending on the [MKL](https://en.wikipedia.org/wiki/Math_Kernel_Library) linear algebra libraries using [Conda](https://conda.io).
 
 
 - [cxx-example](cxx-example/)

--- a/chapter-11/recipe-05/abstract.md
+++ b/chapter-11/recipe-05/abstract.md
@@ -1,1 +1,1 @@
-We show how to package a C++ executable depending on the MKL linear algebra libraries using Conda.
+We show how to package a C++ executable depending on the [MKL](https://en.wikipedia.org/wiki/Math_Kernel_Library) linear algebra libraries using [Conda](https://conda.io).

--- a/chapter-13/recipe-01/README.md
+++ b/chapter-13/recipe-01/README.md
@@ -1,6 +1,6 @@
 # Cross-compiling a hello world example
 
-This recipes shows how to cross-compile a simple C++ "hello world" executable from
+This recipes shows how to [cross-compile](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling) a simple C++ "hello world" executable from
 GNU/Linux or macOS to Windows.
 
 

--- a/chapter-13/recipe-01/abstract.md
+++ b/chapter-13/recipe-01/abstract.md
@@ -1,2 +1,2 @@
-This recipes shows how to cross-compile a simple C++ "hello world" executable from
+This recipes shows how to [cross-compile](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling) a simple C++ "hello world" executable from
 GNU/Linux or macOS to Windows.

--- a/chapter-13/recipe-02/README.md
+++ b/chapter-13/recipe-02/README.md
@@ -1,6 +1,6 @@
 # Cross-compiling a Windows binary with OpenMP parallelization
 
-We show how to cross-compile an executable using OpenMP threading from GNU/Linux to Windows.
+We show how to cross-compile an executable using [OpenMP](https://www.openmp.org/) threading from GNU/Linux to Windows.
 Both a C++ and a Fortran example are given.
 
 

--- a/chapter-13/recipe-02/abstract.md
+++ b/chapter-13/recipe-02/abstract.md
@@ -1,2 +1,2 @@
-We show how to cross-compile an executable using OpenMP threading from GNU/Linux to Windows.
+We show how to cross-compile an executable using [OpenMP](https://www.openmp.org/) threading from GNU/Linux to Windows.
 Both a C++ and a Fortran example are given.


### PR DESCRIPTION

## Description

Add link to CMake documentation when appropriate.
Sometimes add link to external tools as well.

## Motivation and Context

This would make navigation using Github READMEs and external references easier.

## How Has This Been Tested?

Thorough read of the abstract.md and sporadic check on github WebUI.

## Status

- [X]  Ready to go
