### PR TITLE
Almost conda pinning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ cache:
   - c:\Deps\conda\ -> testing\dependencies\appveyor\anaconda.ps1
 
 image:
-  - Previous Visual Studio 2017
+  - Visual Studio 2017
 
 environment:
   # Create expected SHELL variable for pipenv.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,34 +8,26 @@ build:
 cache:
   - c:\tools\vcpkg\installed\ -> testing\dependencies\appveyor\install.bat
   - c:\msys64\var\cache\pacman\pkg -> testing\dependencies\appveyor\install.bat
-  - c:\Deps\boost_1_67_0 -> testing\dependencies\appveyor\boost.bat
   - c:\Deps\conda\ -> testing\dependencies\appveyor\anaconda.ps1
+  - c:\Deps\boost_1_67_0 -> testing\dependencies\appveyor\boost.bat
 
 image:
   - Visual Studio 2017
 
 environment:
   # Create expected SHELL variable for pipenv.
-  SHELL: "windows"
-  CTEST_OUTPUT_ON_FAILURE: "1"
+  SHELL: 'windows'
+  CTEST_OUTPUT_ON_FAILURE: '1'
   matrix:
-    - CMAKE_GENERATOR: "MSYS Makefiles"
-      BUILDFLAGS: "VERBOSE=1"
-      CMAKEARGS: ""
-    - CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
-      BUILDFLAGS: "/verbosity:normal"
-      CMAKEARGS: ""
-    - CMAKE_GENERATOR: "Ninja"
-      BUILDFLAGS: "-v"
-      CMAKEARGS: ""
-    - CMAKE_GENERATOR: "MSYS Makefiles"
-      ANACONDA_TESTS_ONLY: "1"
-      BUILDFLAGS: "VERBOSE=1"
-      CMAKEARGS: ""
-    - CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
-      ANACONDA_TESTS_ONLY: "1"
-      BUILDFLAGS: "/verbosity:normal"
-      CMAKEARGS: ""
+    - CMAKE_GENERATOR: 'MSYS Makefiles'
+      BUILDFLAGS: 'VERBOSE=1'
+    - CMAKE_GENERATOR: 'Visual Studio 15 2017 Win64'
+      BUILDFLAGS: '/verbosity:normal'
+    - CMAKE_GENERATOR: 'Ninja'
+      BUILDFLAGS: '-v'
+    - CMAKE_GENERATOR: 'Visual Studio 15 2017 Win64'
+      BUILDFLAGS: '/verbosity:normal'
+      ANACONDA_TESTS_ONLY: '1'
 
 matrix:
   fast_finish: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,8 +64,7 @@ build_script:
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv lock"
   - bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv install"
   - if "%ANACONDA_TESTS_ONLY%"=="1" (
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'" &&
-      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-05'"
+      bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-11/recipe-04'"
     ) else (
       bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-01/recipe-*'" &&
       bash -c "cd /c/projects/cmake-cookbook-no-symlinks && pipenv run python testing/collect_tests.py 'chapter-02/recipe-*'" &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## [Unreleased]
+
+## [Version 1.0] - 2018-09-XY
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+[Unreleased]: https://github.com/dev-cafe/cmake-cookbook/compare/v1.0...HEAD
+[Version 1.0]: https://github.com/dev-cafe/cmake-cookbook/releases/tag/v1.0
+
+[GitHub]: https://github.com/dev-cafe/cmake-cookbook

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ published by Packt and authored by [Radovan Bast](https://github.com/bast) and
 - [1. Installing your project](chapter-10/recipe-01/README.md)
 - [2. Generating export headers](chapter-10/recipe-02/README.md)
 - [3. Exporting your targets](chapter-10/recipe-03/README.md)
-- [4. Installing a superbuild project](chapter-10/recipe-04/README.md)
+- [4. Installing a superbuild](chapter-10/recipe-04/README.md)
 
 
 ### [Chapter 11: Packaging Projects](chapter-11/README.md)

--- a/chapter-01/recipe-01/fortran-example/menu.yml
+++ b/chapter-01/recipe-01/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-01/recipe-02/fortran-example/menu.yml
+++ b/chapter-01/recipe-02/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-01/recipe-03/fortran-example/menu.yml
+++ b/chapter-01/recipe-03/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-01/recipe-09/fortran-example/menu.yml
+++ b/chapter-01/recipe-09/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-02/recipe-03/fortran-example/menu.yml
+++ b/chapter-02/recipe-03/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-02/recipe-06/cxx-example/menu.yml
+++ b/chapter-02/recipe-06/cxx-example/menu.yml
@@ -5,14 +5,14 @@ circle-intel:
 circle-pgi:
   definitions:
     - Eigen3_DIR: '/opt/eigen/share/eigen3/cmake'
-      
+
 travis-linux:
   definitions:
     - Eigen3_DIR: '$HOME/Deps/eigen/share/eigen3/cmake'
 
 # OpenMP does not work with clang
 travis-osx:
-  failing_generators:
+  skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 

--- a/chapter-03/recipe-04/cxx-example/menu.yml
+++ b/chapter-03/recipe-04/cxx-example/menu.yml
@@ -1,3 +1,4 @@
+# No suitable native BLAS/LAPACK with MSVC
 appveyor-vs:
   failing_generators:
     - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-05/cxx-example-3.5/menu.yml
+++ b/chapter-03/recipe-05/cxx-example-3.5/menu.yml
@@ -1,5 +1,5 @@
 # OpenMP does not work with clang
 travis-osx:
-  failing_generators:
+  skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-05/cxx-example/menu.yml
+++ b/chapter-03/recipe-05/cxx-example/menu.yml
@@ -1,5 +1,5 @@
 # OpenMP does not work with clang
 travis-osx:
-  failing_generators:
+  skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'

--- a/chapter-03/recipe-05/fortran-example-3.5/menu.yml
+++ b/chapter-03/recipe-05/fortran-example-3.5/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-03/recipe-05/fortran-example/menu.yml
+++ b/chapter-03/recipe-05/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-03/recipe-06/c-example-3.5/menu.yml
+++ b/chapter-03/recipe-06/c-example-3.5/menu.yml
@@ -4,7 +4,8 @@ appveyor-vs:
     - MSMPI_INC: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Include\'
     - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
     - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
-      
+
+# No suitable MPI with MSYS
 appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'

--- a/chapter-03/recipe-06/c-example/menu.yml
+++ b/chapter-03/recipe-06/c-example/menu.yml
@@ -5,6 +5,7 @@ appveyor-vs:
     - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
     - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
 
+# No suitable MPI with MSYS
 appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'

--- a/chapter-03/recipe-06/cxx-example/menu.yml
+++ b/chapter-03/recipe-06/cxx-example/menu.yml
@@ -5,6 +5,7 @@ appveyor-vs:
     - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
     - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
 
+# No suitable MPI with MSYS
 appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'

--- a/chapter-03/recipe-07/cxx-example-3.5/menu.yml
+++ b/chapter-03/recipe-07/cxx-example-3.5/menu.yml
@@ -16,7 +16,7 @@ travis-linux:
 
 # OpenMP does not work with clang
 travis-osx:
-  failing_generators:
+  skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 

--- a/chapter-03/recipe-07/cxx-example/menu.yml
+++ b/chapter-03/recipe-07/cxx-example/menu.yml
@@ -16,7 +16,7 @@ travis-linux:
 
 # OpenMP does not work with clang
 travis-osx:
-  failing_generators:
+  skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 

--- a/chapter-03/recipe-09/c-example-3.5/menu.yml
+++ b/chapter-03/recipe-09/c-example-3.5/menu.yml
@@ -1,3 +1,4 @@
+# No pkg-config with Visual Studio generator
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'

--- a/chapter-03/recipe-09/c-example/menu.yml
+++ b/chapter-03/recipe-09/c-example/menu.yml
@@ -1,5 +1,6 @@
+# No pkg-config with Visual Studio generator
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 # Fails to generate imported target for ZeroMQ

--- a/chapter-05/recipe-03/cxx-example/menu.yml
+++ b/chapter-05/recipe-03/cxx-example/menu.yml
@@ -1,6 +1,6 @@
 appveyor-vs:
-  failing_generators:
-    - 'Visual Studio 15 2017 Win64' 
+  skip_generators:
+    - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:
   failing_generators:

--- a/chapter-05/recipe-04/cxx-example/menu.yml
+++ b/chapter-05/recipe-04/cxx-example/menu.yml
@@ -1,6 +1,6 @@
 appveyor-vs:
-  failing_generators:
-    - 'Visual Studio 15 2017 Win64' 
+  skip_generators:
+    - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:
   failing_generators:

--- a/chapter-05/recipe-05/fortran-example/menu.yml
+++ b/chapter-05/recipe-05/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-05/recipe-08/c-example-3.5/menu.yml
+++ b/chapter-05/recipe-08/c-example-3.5/menu.yml
@@ -1,7 +1,9 @@
+# No pkg-config with Visual Studio generator
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
+# UUID can't be found on MSYS
 appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'

--- a/chapter-05/recipe-08/c-example/menu.yml
+++ b/chapter-05/recipe-08/c-example/menu.yml
@@ -1,7 +1,9 @@
+# No pkg-config with Visual Studio generator
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
+# UUID can't be found on MSYS
 appveyor-msys:
   failing_generators:
     - 'MSYS Makefiles'

--- a/chapter-05/recipe-09/cxx-example/menu.yml
+++ b/chapter-05/recipe-09/cxx-example/menu.yml
@@ -5,7 +5,8 @@ appveyor-vs:
     - MSMPI_LIB32: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86\'
     - MSMPI_LIB64: 'C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\'
 
+# No suitable MPI with MSYS
 appveyor-msys:
-  failing_generators:
+  skip_generators:
     - 'MSYS Makefiles'
     - 'Ninja'

--- a/chapter-06/recipe-01/fortran-c-example/menu.yml
+++ b/chapter-06/recipe-01/fortran-c-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-06/recipe-02/fortran-c-example/menu.yml
+++ b/chapter-06/recipe-02/fortran-c-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-06/recipe-04/fortran-example/menu.yml
+++ b/chapter-06/recipe-04/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-07/recipe-09/fortran-example/menu.yml
+++ b/chapter-07/recipe-09/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:
@@ -10,5 +10,9 @@ targets:
   - test
 
 travis-linux:
+  failing_generators:
+    - 'Ninja'
+
+travis-osx:
   failing_generators:
     - 'Ninja'

--- a/chapter-09/recipe-01/fortran-c-example/menu.yml
+++ b/chapter-09/recipe-01/fortran-c-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-09/recipe-01/fortran-cxx-example/menu.yml
+++ b/chapter-09/recipe-01/fortran-cxx-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-09/recipe-01/fortran-uuid-example-3.5/menu.yml
+++ b/chapter-09/recipe-01/fortran-uuid-example-3.5/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-09/recipe-01/fortran-uuid-example/menu.yml
+++ b/chapter-09/recipe-01/fortran-uuid-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-09/recipe-02/cxx-example/menu.yml
+++ b/chapter-09/recipe-02/cxx-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-09/recipe-06/fortran-example/menu.yml
+++ b/chapter-09/recipe-06/fortran-example/menu.yml
@@ -2,7 +2,7 @@ targets:
   - test
 
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-10/README.md
+++ b/chapter-10/README.md
@@ -3,4 +3,4 @@
 - [1. Installing your project](recipe-01/README.md)
 - [2. Generating export headers](recipe-02/README.md)
 - [3. Exporting your targets](recipe-03/README.md)
-- [4. Installing a superbuild project](recipe-04/README.md)
+- [4. Installing a superbuild](recipe-04/README.md)

--- a/chapter-10/recipe-04/README.md
+++ b/chapter-10/recipe-04/README.md
@@ -1,4 +1,4 @@
-# Installing a superbuild project
+# Installing a superbuild
 
 This recipe shows how to install a superbuild which depends on a library which
 may or may not be available on the system.

--- a/chapter-10/recipe-04/title.txt
+++ b/chapter-10/recipe-04/title.txt
@@ -1,1 +1,1 @@
-Installing a superbuild project
+Installing a superbuild

--- a/chapter-11/recipe-03/fortran-example/menu.yml
+++ b/chapter-11/recipe-03/fortran-example/menu.yml
@@ -1,5 +1,5 @@
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:

--- a/chapter-11/recipe-04/cxx-example/custom.sh
+++ b/chapter-11/recipe-04/cxx-example/custom.sh
@@ -19,19 +19,23 @@ cp ../example.cpp .
 if [[ "$OSTYPE" == "msys" ]]; then
     conda.exe config --set always_yes yes --set changeps1 no
 
-    conda.exe build conda-recipe
+    conda.exe build --no-anaconda-upload conda-recipe
 
-    conda.exe install --use-local conda-example-simple
+    conda.exe install --no-update-dependencies --use-local --yes conda-example-simple
 
     hello-conda.exe
+
+    conda.exe clean --all --yes
 else
     PATH=$HOME/Deps/conda/bin${PATH:+:$PATH}
 
-    conda build conda-recipe
+    conda build --no-anaconda-upload conda-recipe
 
-    conda install --use-local conda-example-simple
+    conda install --no-update-deps --use-local --yes conda-example-simple
 
     hello-conda
+
+    conda clean --all --yes
 fi
 
 exit $?

--- a/chapter-11/recipe-04/cxx-example/menu.yml
+++ b/chapter-11/recipe-04/cxx-example/menu.yml
@@ -1,3 +1,3 @@
 local:
   env:
-    - VERBOSE_OUTPUT: 'True'
+    - VERBOSE_OUTPUT: 'ON'

--- a/chapter-11/recipe-05/cxx-example/conda-recipe/meta.yaml
+++ b/chapter-11/recipe-05/cxx-example/conda-recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - cmake >=3.5
     - {{ compiler('cxx') }}
   host:
+    - intel-openmp 2018
     - mkl-devel 2018
 
 about:

--- a/chapter-11/recipe-05/cxx-example/conda-recipe/meta.yaml
+++ b/chapter-11/recipe-05/cxx-example/conda-recipe/meta.yaml
@@ -13,11 +13,11 @@ build:
     - cmake --build build_conda --target install
 
 requirements:
-  host:
-    - mkl-devel 2018
   build:
     - cmake >=3.5
     - {{ compiler('cxx') }}
+  host:
+    - mkl-devel 2018
 
 about:
   home: http://www.example.com

--- a/chapter-11/recipe-05/cxx-example/custom.sh
+++ b/chapter-11/recipe-05/cxx-example/custom.sh
@@ -19,19 +19,23 @@ cp ../example.cpp .
 if [[ "$OSTYPE" == "msys" ]]; then
     conda.exe config --set always_yes yes --set changeps1 no
 
-    conda.exe build conda-recipe
+    conda.exe build --no-anaconda-upload conda-recipe
 
-    conda.exe install --use-local conda-example-dgemm
+    conda.exe install --no-update-deps --use-local --yes conda-example-dgemm
 
     dgemm-example.exe
+
+    conda.exe clean --all --yes
 else
     PATH=$HOME/Deps/conda/bin${PATH:+:$PATH}
 
-    conda build conda-recipe
+    conda build --no-anaconda-upload conda-recipe
 
-    conda install --use-local conda-example-dgemm
+    conda install --no-update-deps --use-local --yes conda-example-dgemm
 
     dgemm-example
+
+    conda clean --all --yes
 fi
 
 exit $?

--- a/chapter-11/recipe-05/cxx-example/menu.yml
+++ b/chapter-11/recipe-05/cxx-example/menu.yml
@@ -1,3 +1,7 @@
+appveyor-vs:
+  env:
+    - VERBOSE_OUTPUT: 'ON'
+
 local:
   env:
-    - VERBOSE_OUTPUT: 'True'
+    - VERBOSE_OUTPUT: 'ON'

--- a/chapter-13/recipe-02/fortran-example/menu.yml
+++ b/chapter-13/recipe-02/fortran-example/menu.yml
@@ -3,7 +3,7 @@ targets:
   - install
 
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 appveyor-msys:
@@ -11,7 +11,7 @@ appveyor-msys:
     - 'Ninja'
 
 travis-osx:
-  failing_generators:
+  skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'
 

--- a/chapter-14/recipe-03/fortran-example/menu.yml
+++ b/chapter-14/recipe-03/fortran-example/menu.yml
@@ -1,8 +1,9 @@
 targets:
   - test
 
+# No ASan on Windows
 appveyor-vs:
-  failing_generators:
+  skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
 # No ASan on Windows

--- a/chapter-14/recipe-04/cxx-example/menu.yml
+++ b/chapter-14/recipe-04/cxx-example/menu.yml
@@ -6,6 +6,7 @@ appveyor-vs:
   skip_generators:
     - 'Visual Studio 15 2017 Win64'
 
+# No TSan on Windows
 appveyor-msys:
   skip_generators:
     - 'MSYS Makefiles'
@@ -13,6 +14,6 @@ appveyor-msys:
 
 # OpenMP does not work with clang
 travis-osx:
-  failing_generators:
+  skip_generators:
     - 'Unix Makefiles'
     - 'Ninja'

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -24,8 +24,9 @@ To update the README files, run `python contributing/generate-readmes.py` - this
 
 #### Indentation
 
-We use 2 spaces instead of 4 spaces to reduce the printed page width.
-No tabs.
+We use 2 spaces instead of 4 spaces to reduce the printed page width. No tabs.
+Get the integration for [EditorConfig](https://editorconfig.org/) in your
+favorite editor to help you keep the conventions.
 
 
 #### Case of commands

--- a/testing/README.md
+++ b/testing/README.md
@@ -70,6 +70,22 @@ appveyor-msys:
     - 'MSYS Makefiles'
 ```
 
+## When to use `failing_generators` and `skip_generators`
+
+Marking generators as expected failures or skipping them achieves more or less
+the same goal: not failing CI for recipes that are known not to work under
+certain conditions. Using `failing_generators` means that the recipe is actually
+tested, but the possible failure is not elevated to an error; whereas using
+`skip_generators` will skip the testing altogether.
+The semantic to differentiate the use of the two is thus:
+1. Use `failing_generators` if the recipe does not work under the current CI set
+   up, but _it could be made_ to work. As an example, the Ninja is always marked as
+   an expected failure for Fortran recipes, since its set up is rather contrived,
+   requiring specific versions specific versions of CMake _and_ Ninja.
+   The hurdle could however be overcome in the future.
+2. Use `skip_generators` when _you cannot foresee any way_ to make the recipe work.
+   This is the case for the Fortran recipes with the Visual Studio generators.
+
 
 ## Bulding targets
 

--- a/testing/collect_tests.py
+++ b/testing/collect_tests.py
@@ -55,6 +55,8 @@ def run_command(*, step, command, expect_failure):
     # Stream stderr always
     stderr_streamer = functools.partial(streamer, file_handle=sys.stderr)
     stderr = ''
+    # subprocess.Popen can be managed as a context and allows us to stream
+    # stdout and stderr in real-time
     with subprocess.Popen(
             cmd,
             bufsize=1,
@@ -166,6 +168,7 @@ def run_example(topdir, generator, ci_environment, buildflags, recipe, example):
     custom_script = 'custom.sh'
     custom_script_path = cmakelists_path / custom_script
     if custom_script_path.exists():
+        sys.stdout.write('\nRunning a custom.sh script\n')
         # if this directory contains a custom.sh script, we launch it
         step = custom_script
         command = 'bash "{0}" "{1}"'.format(custom_script_path, build_directory)

--- a/testing/dependencies/appveyor/anaconda.ps1
+++ b/testing/dependencies/appveyor/anaconda.ps1
@@ -83,7 +83,7 @@ function SetUpConda ($Anaconda_cache) {
     Write-Host $conda_path $args
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 
-    $args = "install --yes --quiet conda-build anaconda-client jinja2 setuptools"
+    $args = "install --yes --quiet conda-build anaconda-client conda-verify jinja2 setuptools"
     Write-Host $conda_path $args
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 

--- a/testing/dependencies/travis/anaconda.sh
+++ b/testing/dependencies/travis/anaconda.sh
@@ -25,7 +25,7 @@ else
     conda update --all --yes &> /dev/null
     conda clean -tipy &> /dev/null
     # Install conda build and deployment tools.
-    conda install --yes --quiet conda-build anaconda-client jinja2 setuptools &> /dev/null
+    conda install --yes --quiet conda-build anaconda-client conda-verify jinja2 setuptools &> /dev/null
     conda clean -tipsy &> /dev/null
     conda info -a
     cd "$TRAVIS_BUILD_DIR"


### PR DESCRIPTION
This does what #487 attempted to do. Since we can't seem to get the Conda+MKL example to work on Appveyor, we skip that one. Followed up in #497
- [x] Pin MKL to any of its 2018 versions (2019 seems to make trouble on CI)
- [x] Use `Visual Studio 2017` image on Appveyor (rather than the "previous" version)
- [x] Add stub of change log
- [x] Skip certain generators altogether for certain recipes. Mainly in the hope that it speeds up the Visual Studio lanes on Appveyor.
- [x] Document difference between `skip_generators` and `failing_generators`

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
