### PR TITLE
Add AUTHORS.md and .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Roberto Di Remigio <roberto.diremigio@gmail.com> <roberto.d.remigio@uit.no>
+Eric Noulard <eric.noulard@gmail.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,7 @@
+## Individual Contributors
+
+- Radovan Bast (@bast)
+- Roberto Di Remigio (@robertodr)
+- Eric Noulard (@TheErk)
+
+This list was obtained 2018-09-23 by running `git shortlog -sn`


### PR DESCRIPTION
Does what it says on the tin. The list in `AUTHORS.md` was generated using `git shortlog -sn`, so authors are ordered by number of commits. Which also happens to be alphabetic order on surnames!

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
